### PR TITLE
feat: initial implementation of pnpm-override-prune

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,42 @@
+name: Compatibility
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  per-node:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20', '22', '24']
+    permissions:
+      contents: read
+    env:
+      MISE_NODE_VERSION: ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          experimental: true
+          cache: false
+          install: false
+      - run: bash compatibility.sh
+
+  compatibility:
+    needs:
+      - per-node
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions: {}
+    steps:
+      - run: 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish
+
+on:
+  push:
+    tags: ['v*.*.*']
+
+permissions:
+  contents: read
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          experimental: true
+          cache: false
+      - run: aube install --frozen-lockfile
+      - run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm pkg set version="$VERSION"
+      - run: aube run build
+      - run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          npm publish --provenance --access public
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,4 +11,7 @@ permissions:
 
 jobs:
   validate:
-    uses: iwamot/workflows/.github/workflows/validate.yml@d718704d344724f106df3152191d71859c0f3715 # v1.3.0
+    permissions:
+      contents: read
+      id-token: write
+    uses: iwamot/workflows/.github/workflows/validate-with-coverage.yml@d718704d344724f106df3152191d71859c0f3715 # v1.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Build output
+dist/
+
+# Dependencies
+node_modules/
+.pnpm-debug.log*
+
+# Coverage
+coverage/
+*.lcov
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Claude Code
+.claude/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+*.tmp
+*.temp
+.cache/

--- a/README.md
+++ b/README.md
@@ -1,37 +1,102 @@
-# repo-template
+# pnpm-override-prune
 
-Starter template for repositories in iwamot's ecosystem.
+[![Validate](https://github.com/iwamot/pnpm-override-prune/actions/workflows/validate.yml/badge.svg)](https://github.com/iwamot/pnpm-override-prune/actions/workflows/validate.yml)
+[![codecov](https://codecov.io/gh/iwamot/pnpm-override-prune/graph/badge.svg)](https://codecov.io/gh/iwamot/pnpm-override-prune)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## Files
+Detect prunable override entries in pnpm / [aube](https://github.com/endevco/aube) projects.
 
-| Path | Purpose |
+## Install
+
+```bash
+pnpm dlx pnpm-override-prune
+# or
+aube dlx pnpm-override-prune
+```
+
+## Usage
+
+```bash
+# Detect prunable entries (default)
+pnpm-override-prune                          # checks ./package.json
+pnpm-override-prune path/to/package.json     # checks given file
+
+# Remove prunable entries in place
+pnpm-override-prune --fix
+```
+
+Example output:
+
+```
+=== package.json:pnpm.overrides (2 entries) ===
+[PRUNE] @xmldom/xmldom >=0.9.10  0.9.10
+[PRUNE] postcss >=8.5.10         8.5.12
+
+Run with --fix to prune entries marked [PRUNE].
+```
+
+Exit codes:
+
+| Code | Meaning |
 |------|---------|
-| `.github/dco.yml` | DCO Bot config. Allows individual remediation commits for missing sign-offs. |
-| `.github/release.yml` | GitHub auto-generated release notes categorization (Features / Dependencies). |
-| `.github/renovate.json` | Extends `iwamot/renovate-config` preset. |
-| `.github/workflows/validate.yml` | Runs `validate.sh` on push and PR via `iwamot/workflows`. |
-| `.github/workflows/renovate.yml` | Self-hosted Renovate runner (hourly + on push to main). |
-| `.github/workflows/dependency-review.yml` | Vulnerability and license review on PRs. |
-| `.github/workflows/dependabot-auto-merge.yml` | Auto-merges Dependabot PRs. |
-| `mise.toml` | Pins mise minimum version and includes shared tasks from `iwamot/mise-tasks`. |
-| `validate.sh` | Lint entry point invoked by `iwamot/actions/mise-validate`. Add repo-specific lint at the marked location. |
+| `0`  | No prunable entries (or `--fix` succeeded) |
+| `1`  | Prunable entries found (without `--fix`) |
+| `2`  | `package.json` or lockfile not found, or parse error |
 
-## Post-creation setup
+## Why
 
-After clicking **Use this template**:
+pnpm and aube let you pin a transitive dependency version via override
+entries — in `package.json` (`pnpm.overrides` or top-level `overrides`)
+or in `pnpm-workspace.yaml` / `aube-workspace.yaml` (top-level
+`overrides:`). A common reason to reach for these is CVE
+mitigation: a vulnerability is disclosed in a transitive package, and you
+force the patched minimum version while waiting for direct deps to require
+it naturally. Once they catch up, the entry is no longer doing anything —
+but it's easy to forget which ones are still load-bearing, and stale
+overrides become a judgment cost at every audit or upgrade ("is this still
+needed, or just history?"). `pnpm-override-prune` answers that mechanically
+by checking whether each entry's lower bound is already satisfied by the
+natural resolution that the npm registry would yield without the override.
 
-1. **Replace this README.md** with the new repository's own description.
-2. **Install GitHub Apps** for the new repo:
-   - [DCO](https://github.com/apps/dco) — sign-off enforcement
-   - Renovate App (or your self-hosted equivalent)
-3. **Create a GitHub Environment** for Renovate (default name: `production`, override via the `environment` input on `renovate.yml` if needed) and add environment-scoped secrets:
-   - `RENOVATE_APP_ID`
-   - `RENOVATE_PRIVATE_KEY`
-4. **Add a publish workflow** if the repo ships artifacts. These also take an `environment` input — create additional environments as needed:
-   - `iwamot/workflows/.github/workflows/publish-ghcr.yml` for GHCR
-   - `iwamot/workflows/.github/workflows/publish-ecr-public.yml` for ECR Public
-5. **Add language-specific files** as needed: `Dockerfile`, `package.json`, `pyproject.toml`, `.gitignore`, etc.
-6. **Extend `validate.sh`** with repo-specific lint (e.g. `mise run docker-lint Dockerfile`, language linters).
-7. **Review `mise.toml`'s `min_version`**: the template provides a default, but the minimum mise version is each repository's own decision. Bump it if your tasks require a newer feature, or drop it if no constraint is needed. This is *not* auto-bumped by Renovate.
+## Scope
 
-Renovate runs on this template to keep pinned versions in `.github/workflows/*.yml` and `mise.toml`'s `task_config.includes` reasonably current, but derived repositories are responsible for their own updates going forward — enable Renovate and let it track upstream from there.
+- Reads override entries from these locations:
+  - `package.json` &rarr; `pnpm.overrides`
+  - `package.json` &rarr; top-level `overrides` (npm-compatible form, also
+    used by `aube audit --fix`)
+  - `pnpm-workspace.yaml` or `aube-workspace.yaml` &rarr; top-level `overrides:`
+- When the same key appears in both `pnpm.overrides` and top-level
+  `overrides`, both entries are evaluated and reported independently
+  (pnpm gives `pnpm.overrides` precedence at install time, but the tool
+  surfaces both so dead duplicates can be cleaned up).
+- Only entries whose specifier uses `>=` and/or `>` are checked. Entries
+  using exact pins (`1.2.3`), caret (`^1.2.3`), tilde (`~1.2.3`), or
+  bounded ranges are skipped — removing an upper bound the user wrote
+  intentionally is unsafe.
+- Lockfile must be `pnpm-lock.yaml` or `aube-lock.yaml` at
+  `lockfileVersion: '9.0'` (pnpm 9+ / aube). Older formats are not
+  supported in this release.
+- Detection method: the tool gathers the parent specs that constrain each
+  override target — direct importer specs from the lockfile plus
+  parent-package metadata from `https://registry.npmjs.org` — and computes
+  the highest published version satisfying their intersection. If that
+  natural resolution already meets the override's lower bound, the entry
+  is `[PRUNE]`.
+
+## Known limitations
+
+- Skips entries whose value is a non-semver protocol (`catalog:`,
+  `workspace:`, `file:`, `link:`, `portal:`, `npm:`, `github:`, `git`-prefixed,
+  `http:` / `https:`).
+- Skips nested-key overrides like `"parent>child": "1.2.3"`. Only flat
+  `name &rarr; spec` mappings are evaluated.
+- Public npm registry only. Private registries / scoped registry
+  configuration in `.npmrc` are not consulted.
+- Parents that aren't on the public registry (workspace-internal packages
+  resolved as transitive parents) are silently dropped from the constraint
+  set, which can make the natural resolution appear less constrained than
+  it really is.
+
+## License
+
+MIT

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -1,0 +1,199 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+time:
+  '@biomejs/biome@2.4.13': 2026-04-23T15:40:57.553Z
+  '@biomejs/cli-darwin-arm64@2.4.13': 2026-04-23T15:41:08.668Z
+  '@biomejs/cli-linux-arm64-musl@2.4.13': 2026-04-23T15:41:33.094Z
+  '@biomejs/cli-linux-arm64@2.4.13': 2026-04-23T15:41:26.398Z
+  '@biomejs/cli-linux-x64-musl@2.4.13': 2026-04-23T15:41:51.908Z
+  '@biomejs/cli-linux-x64@2.4.13': 2026-04-23T15:41:43.305Z
+  '@biomejs/cli-win32-arm64@2.4.13': 2026-04-23T15:42:00.706Z
+  '@biomejs/cli-win32-x64@2.4.13': 2026-04-23T15:42:10.153Z
+  '@types/bun@1.3.13': 2026-04-22T15:55:43.685Z
+  '@types/node@25.6.0': 2026-04-10T03:39:59.421Z
+  '@types/semver@7.7.1': 2025-09-03T15:02:35.366Z
+  bun-types@1.3.13: 2026-04-20T08:09:49.687Z
+  semver@7.7.4: 2026-02-05T17:23:11.131Z
+  typescript@6.0.3: 2026-04-16T23:38:27.905Z
+  undici-types@7.19.2: 2026-01-27T20:25:15.804Z
+  yaml@2.8.3: 2026-03-21T10:37:06.001Z
+
+importers:
+
+  .:
+    dependencies:
+      semver:
+        specifier: 7.7.4
+        version: 7.7.4
+      yaml:
+        specifier: 2.8.3
+        version: 2.8.3
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.4.13
+        version: 2.4.13
+      '@types/bun':
+        specifier: 1.3.13
+        version: 1.3.13
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      '@types/semver':
+        specifier: 7.7.1
+        version: 7.7.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+packages:
+
+  '@biomejs/biome@2.4.13':
+    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - darwin
+    cpu:
+    - arm64
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - win32
+    cpu:
+    - arm64
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - win32
+    cpu:
+    - x64
+
+  '@types/bun@1.3.13':
+    resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
+  bun-types@1.3.13:
+    resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+snapshots:
+
+  '@biomejs/biome@2.4.13':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64-musl': 2.4.13
+      '@biomejs/cli-linux-x64': 2.4.13
+      '@biomejs/cli-linux-x64-musl': 2.4.13
+      '@biomejs/cli-win32-arm64': 2.4.13
+      '@biomejs/cli-win32-x64': 2.4.13
+
+  '@biomejs/cli-darwin-arm64@2.4.13': {}
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13': {}
+
+  '@biomejs/cli-linux-arm64@2.4.13': {}
+
+  '@biomejs/cli-linux-x64-musl@2.4.13': {}
+
+  '@biomejs/cli-linux-x64@2.4.13': {}
+
+  '@biomejs/cli-win32-arm64@2.4.13': {}
+
+  '@biomejs/cli-win32-x64@2.4.13': {}
+
+  '@types/bun@1.3.13':
+    dependencies:
+      bun-types: 1.3.13
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
+  '@types/semver@7.7.1': {}
+
+  bun-types@1.3.13:
+    dependencies:
+      '@types/node': 25.6.0
+
+  semver@7.7.4: {}
+
+  typescript@6.0.3: {}
+
+  undici-types@7.19.2: {}
+
+  yaml@2.8.3: {}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "files": {
+    "includes": ["src/**", "tests/**"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "error"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/compatibility.sh
+++ b/compatibility.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+# mise
+eval "$(mise activate bash)"
+mise install
+
+aube install --frozen-lockfile
+aube run build
+
+# Pack the package and install it in an isolated directory to exercise the
+# publish path (validates "files" globs, bin shebang, deps resolution).
+TARBALL="$PWD/$(npm pack --silent)"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"; rm -f "$TARBALL"' EXIT
+
+cd "$TMP"
+npm init --silent --yes > /dev/null
+npm install --silent --no-audit --no-fund "$TARBALL"
+
+./node_modules/.bin/pnpm-override-prune --version
+./node_modules/.bin/pnpm-override-prune --help > /dev/null

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,9 @@ min_version = "2026.4.8"
 install_before = "1d"
 
 [tools]
+bun = "1.3.13"
+node = "24.15.0"
+"npm:@endevco/aube" = "1.2.0"
 
 [task_config]
 includes = [

--- a/package.json
+++ b/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "pnpm-override-prune",
+  "version": "0.0.0",
+  "description": "Detect prunable pnpm.overrides entries by checking the npm registry against pnpm-lock.yaml.",
+  "license": "MIT",
+  "author": "Takashi Iwamoto",
+  "homepage": "https://github.com/iwamot/pnpm-override-prune",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iwamot/pnpm-override-prune.git"
+  },
+  "bugs": {
+    "url": "https://github.com/iwamot/pnpm-override-prune/issues"
+  },
+  "keywords": [
+    "pnpm",
+    "overrides",
+    "audit",
+    "cli"
+  ],
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "pnpm-override-prune": "dist/index.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "bun build src/cli.ts --outfile dist/index.js --target node --packages external --banner \"#!/usr/bin/env node\"",
+    "check": "biome check",
+    "check:write": "biome check --write",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test --coverage --coverage-reporter=lcov --coverage-reporter=text"
+  },
+  "dependencies": {
+    "semver": "7.7.4",
+    "yaml": "2.8.3"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.13",
+    "@types/bun": "1.3.13",
+    "@types/node": "25.6.0",
+    "@types/semver": "7.7.1",
+    "typescript": "6.0.3"
+  }
+}

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,0 +1,73 @@
+import { Range, satisfies } from "semver";
+
+export type Status = "prune" | "keep" | "skip" | "error";
+
+export interface Result {
+  readonly status: Status;
+  readonly value: string;
+}
+
+const PROTOCOL_PREFIXES: readonly string[] = [
+  "catalog:",
+  "workspace:",
+  "file:",
+  "link:",
+  "portal:",
+  "npm:",
+  "github:",
+  "git:",
+  "git+",
+  "http:",
+  "https:",
+];
+
+export function isPureLowerBound(spec: string): boolean {
+  if (spec.length === 0) {
+    return false;
+  }
+  let range: Range;
+  try {
+    range = new Range(spec, { loose: false });
+  } catch {
+    return false;
+  }
+  return range.set.every((group) =>
+    group.every((c) => c.operator === ">=" || c.operator === ">"),
+  );
+}
+
+export function isNestedKey(key: string): boolean {
+  return key.includes(">");
+}
+
+export function hasProtocolPrefix(spec: string): boolean {
+  return PROTOCOL_PREFIXES.some((prefix) => spec.startsWith(prefix));
+}
+
+export type SkipReason = "nested-key" | "protocol-spec" | "non-lower-bound";
+
+export type Categorization =
+  | { readonly kind: "target"; readonly spec: string }
+  | { readonly kind: "skip"; readonly reason: SkipReason };
+
+export function categorize(key: string, spec: string): Categorization {
+  if (isNestedKey(key)) {
+    return { kind: "skip", reason: "nested-key" };
+  }
+  if (hasProtocolPrefix(spec)) {
+    return { kind: "skip", reason: "protocol-spec" };
+  }
+  if (!isPureLowerBound(spec)) {
+    return { kind: "skip", reason: "non-lower-bound" };
+  }
+  return { kind: "target", spec };
+}
+
+export function classify(spec: string, resolved: string | null): Result {
+  if (resolved === null) {
+    return { status: "prune", value: "(unused)" };
+  }
+  return satisfies(resolved, spec, { includePrerelease: true })
+    ? { status: "prune", value: resolved }
+    : { status: "keep", value: resolved };
+}

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,0 +1,50 @@
+import { parseArgs as nodeParseArgs } from "node:util";
+
+export type ParsedArgs =
+  | { readonly kind: "version" }
+  | { readonly kind: "help" }
+  | { readonly kind: "audit"; readonly path: string; readonly fix: boolean }
+  | { readonly kind: "error"; readonly message: string };
+
+export const DEFAULT_PACKAGE_JSON_PATH = "./package.json";
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  let values: Record<string, unknown>;
+  let positionals: readonly string[];
+  try {
+    const parsed = nodeParseArgs({
+      args: [...argv],
+      options: {
+        version: { type: "boolean", short: "V" },
+        help: { type: "boolean", short: "h" },
+        fix: { type: "boolean" },
+      },
+      allowPositionals: true,
+      strict: true,
+    });
+    values = parsed.values;
+    positionals = parsed.positionals;
+  } catch (e) {
+    return {
+      kind: "error",
+      message: e instanceof Error ? e.message : "argument parse error",
+    };
+  }
+  if (values.version === true) {
+    return { kind: "version" };
+  }
+  if (values.help === true) {
+    return { kind: "help" };
+  }
+  if (positionals.length > 1) {
+    return {
+      kind: "error",
+      message: `expected at most one positional argument, got ${positionals.length}`,
+    };
+  }
+  return {
+    kind: "audit",
+    path: positionals[0] ?? DEFAULT_PACKAGE_JSON_PATH,
+    fix: values.fix === true,
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,18 @@
+import { runAudit } from "./core.ts";
+import { decideRun } from "./run.ts";
+import { VERSION } from "./version.ts";
+
+const decision = decideRun(process.argv.slice(2), VERSION);
+
+if (decision.kind === "sync") {
+  if (decision.stdout) {
+    process.stdout.write(decision.stdout);
+  }
+  if (decision.stderr) {
+    process.stderr.write(decision.stderr);
+  }
+  process.exit(decision.exitCode);
+}
+
+const exitCode = await runAudit(decision.path, decision.fix);
+process.exit(exitCode);

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,224 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import {
+  entryWidth,
+  formatLine,
+  formatSectionHeader,
+  formatSummary,
+  SOURCE_ORDER,
+} from "./format.ts";
+import { type Lockfile, parseLockfile } from "./lockfile.ts";
+import {
+  type Override,
+  parsePackageJsonOverrides,
+  parseWorkspaceOverrides,
+  type WorkspaceFilename,
+} from "./manifest.ts";
+import {
+  type AuditEntry,
+  collectPackagesForOverride,
+  evaluateOverride,
+} from "./pipeline.ts";
+import type { PackageMetadata } from "./registry.ts";
+import { createNpmRegistryClient } from "./registry-fetch.ts";
+import { removeFromPackageJson, removeFromWorkspaceYaml } from "./rewrite.ts";
+
+const WORKSPACE_FILENAMES: readonly WorkspaceFilename[] = [
+  "pnpm-workspace.yaml",
+  "aube-workspace.yaml",
+];
+
+const LOCKFILE_FILENAMES: readonly string[] = [
+  "pnpm-lock.yaml",
+  "aube-lock.yaml",
+];
+
+interface FoundFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+async function readFileIfExists(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+async function findFirstExisting(
+  dir: string,
+  filenames: readonly string[],
+): Promise<FoundFile | null> {
+  for (const filename of filenames) {
+    const path = join(dir, filename);
+    const content = await readFileIfExists(path);
+    if (content !== null) {
+      return { path, content };
+    }
+  }
+  return null;
+}
+
+function workspaceFilenameFromPath(path: string): WorkspaceFilename {
+  return path.endsWith("aube-workspace.yaml")
+    ? "aube-workspace.yaml"
+    : "pnpm-workspace.yaml";
+}
+
+function emitError(message: string): void {
+  process.stderr.write(`error: ${message}\n`);
+}
+
+async function applyFix(
+  packageJsonPath: string,
+  packageJsonContent: string,
+  workspace: FoundFile | null,
+  entries: readonly AuditEntry[],
+): Promise<void> {
+  const fromPnpmOverrides: string[] = [];
+  const fromTopLevelOverrides: string[] = [];
+  const byPnpmWorkspace: string[] = [];
+  const byAubeWorkspace: string[] = [];
+  for (const entry of entries) {
+    if (entry.result.status !== "prune") {
+      continue;
+    }
+    switch (entry.override.source) {
+      case "package.json:pnpm.overrides":
+        fromPnpmOverrides.push(entry.override.key);
+        break;
+      case "package.json:overrides":
+        fromTopLevelOverrides.push(entry.override.key);
+        break;
+      case "pnpm-workspace.yaml":
+        byPnpmWorkspace.push(entry.override.key);
+        break;
+      case "aube-workspace.yaml":
+        byAubeWorkspace.push(entry.override.key);
+        break;
+    }
+  }
+  if (fromPnpmOverrides.length > 0 || fromTopLevelOverrides.length > 0) {
+    const updated = removeFromPackageJson(packageJsonContent, {
+      fromPnpmOverrides,
+      fromTopLevelOverrides,
+    });
+    await writeFile(packageJsonPath, updated);
+  }
+  if (workspace !== null) {
+    const wsName = workspaceFilenameFromPath(workspace.path);
+    const keys =
+      wsName === "aube-workspace.yaml" ? byAubeWorkspace : byPnpmWorkspace;
+    if (keys.length > 0) {
+      const updated = removeFromWorkspaceYaml(workspace.content, keys);
+      await writeFile(workspace.path, updated);
+    }
+  }
+}
+
+export async function runAudit(
+  packageJsonPath: string,
+  fix: boolean,
+): Promise<number> {
+  const packageJsonContent = await readFileIfExists(packageJsonPath);
+  if (packageJsonContent === null) {
+    emitError(`file not found: ${packageJsonPath}`);
+    return 2;
+  }
+  const dir = dirname(packageJsonPath);
+  const workspace = await findFirstExisting(dir, WORKSPACE_FILENAMES);
+  const lockResult = await findFirstExisting(dir, LOCKFILE_FILENAMES);
+  if (lockResult === null) {
+    emitError(
+      `no lockfile found in ${dir} (looked for ${LOCKFILE_FILENAMES.join(", ")})`,
+    );
+    return 2;
+  }
+  let allOverrides: readonly Override[];
+  let lockfile: Lockfile;
+  try {
+    const fromPackage = parsePackageJsonOverrides(packageJsonContent);
+    const fromWorkspace =
+      workspace === null
+        ? []
+        : parseWorkspaceOverrides(
+            workspace.content,
+            workspaceFilenameFromPath(workspace.path),
+          );
+    allOverrides = [...fromPackage, ...fromWorkspace];
+    lockfile = parseLockfile(lockResult.content);
+  } catch (e) {
+    emitError(e instanceof Error ? e.message : "parse error");
+    return 2;
+  }
+
+  // Pre-fire all registry fetches in parallel; output streams in entry order
+  // and awaits only the per-entry subset, so per-entry latency is bounded by
+  // the slowest fetch needed for that single entry.
+  const client = createNpmRegistryClient();
+  const fetchPromises = new Map<string, Promise<PackageMetadata | null>>();
+  for (const override of allOverrides) {
+    for (const name of collectPackagesForOverride(override, lockfile)) {
+      if (!fetchPromises.has(name)) {
+        fetchPromises.set(
+          name,
+          client.fetchPackage(name).catch(() => null),
+        );
+      }
+    }
+  }
+
+  const collectedEntries: AuditEntry[] = [];
+  let prunableCount = 0;
+
+  for (const source of SOURCE_ORDER) {
+    const sectionEntries = allOverrides.filter((o) => o.source === source);
+    if (sectionEntries.length === 0) {
+      continue;
+    }
+    process.stdout.write(formatSectionHeader(source, sectionEntries.length));
+    const width = entryWidth(sectionEntries);
+    for (const override of sectionEntries) {
+      const required = collectPackagesForOverride(override, lockfile);
+      const data = await Promise.all(
+        required.map(
+          (name) => fetchPromises.get(name) ?? Promise.resolve(null),
+        ),
+      );
+      const dataMap = new Map<string, PackageMetadata>();
+      for (const [i, name] of required.entries()) {
+        const meta = data[i];
+        if (meta !== null && meta !== undefined) {
+          dataMap.set(name, meta);
+        }
+      }
+      const result = evaluateOverride(override, lockfile, dataMap);
+      const entry: AuditEntry = { override, result };
+      collectedEntries.push(entry);
+      if (result.status === "prune") {
+        prunableCount++;
+      }
+      process.stdout.write(formatLine(entry, width));
+    }
+    process.stdout.write("\n");
+  }
+
+  if (fix && prunableCount > 0) {
+    await applyFix(
+      packageJsonPath,
+      packageJsonContent,
+      workspace,
+      collectedEntries,
+    );
+    process.stdout.write(formatSummary({ prunableCount, fixed: true }));
+    return 0;
+  }
+  if (prunableCount > 0) {
+    process.stdout.write(formatSummary({ prunableCount, fixed: false }));
+    return 1;
+  }
+  process.stdout.write(formatSummary({ prunableCount: 0, fixed: false }));
+  return 0;
+}

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,79 @@
+import type { Override, OverrideSource } from "./manifest.ts";
+import type { AuditEntry } from "./pipeline.ts";
+
+export const LABELS = {
+  prune: "[PRUNE]",
+  keep: "[KEEP] ",
+  skip: "[SKIP] ",
+  error: "[ERROR]",
+} as const;
+
+export const SOURCE_ORDER: readonly OverrideSource[] = [
+  "package.json:overrides",
+  "package.json:pnpm.overrides",
+  "pnpm-workspace.yaml",
+  "aube-workspace.yaml",
+];
+
+export function entryDisplay(override: Override): string {
+  return `${override.key} ${override.spec}`;
+}
+
+export function entryWidth(overrides: readonly Override[]): number {
+  if (overrides.length === 0) {
+    return 0;
+  }
+  return Math.max(...overrides.map((o) => entryDisplay(o).length));
+}
+
+export function formatSectionHeader(
+  source: OverrideSource,
+  count: number,
+): string {
+  const word = count === 1 ? "entry" : "entries";
+  return `=== ${source} (${count} ${word}) ===\n`;
+}
+
+export function formatLine(entry: AuditEntry, width: number): string {
+  const label = LABELS[entry.result.status];
+  const display = entryDisplay(entry.override).padEnd(width);
+  return `${label} ${display}  ${entry.result.value}\n`;
+}
+
+export interface SummaryOptions {
+  readonly prunableCount: number;
+  readonly fixed: boolean;
+}
+
+export function formatSummary(opts: SummaryOptions): string {
+  if (opts.fixed && opts.prunableCount > 0) {
+    const word = opts.prunableCount === 1 ? "entry" : "entries";
+    return `Pruned ${opts.prunableCount} ${word}.\n`;
+  }
+  if (opts.prunableCount > 0) {
+    return "Run with --fix to prune entries marked [PRUNE].\n";
+  }
+  return "No prunable entries found.\n";
+}
+
+export function formatVersion(version: string): string {
+  return `pnpm-override-prune ${version}\n`;
+}
+
+export function formatHelp(): string {
+  return [
+    "Usage: pnpm-override-prune [path] [options]",
+    "",
+    "Detect prunable pnpm.overrides entries by checking the npm registry",
+    "against the local pnpm-lock.yaml / aube-lock.yaml.",
+    "",
+    "Arguments:",
+    "  path           Path to package.json (default: ./package.json)",
+    "",
+    "Options:",
+    "  --fix          Remove prunable entries in place",
+    "  -V, --version  Print the version and exit",
+    "  -h, --help     Print this help and exit",
+    "",
+  ].join("\n");
+}

--- a/src/lockfile.ts
+++ b/src/lockfile.ts
@@ -1,0 +1,188 @@
+import { parse as parseYaml } from "yaml";
+
+export const SUPPORTED_LOCKFILE_VERSION = "9.0";
+
+const DIRECT_DEP_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+export type DirectDepType = (typeof DIRECT_DEP_FIELDS)[number];
+
+export class UnsupportedLockfileVersionError extends Error {
+  override readonly name = "UnsupportedLockfileVersionError";
+  readonly found: string | null;
+  constructor(found: string | null) {
+    super(
+      found === null
+        ? "lockfile is missing 'lockfileVersion' field"
+        : `lockfile version '${found}' is not supported (expected '${SUPPORTED_LOCKFILE_VERSION}')`,
+    );
+    this.found = found;
+  }
+}
+
+export class MalformedLockfileError extends Error {
+  override readonly name = "MalformedLockfileError";
+  constructor(message: string) {
+    super(`malformed lockfile: ${message}`);
+  }
+}
+
+export interface DirectRequirement {
+  readonly importerKey: string;
+  readonly depType: DirectDepType;
+  readonly specifier: string;
+  readonly resolvedVersion: string;
+}
+
+export interface ParentRequirement {
+  readonly parentKey: string;
+  readonly resolvedVersion: string;
+}
+
+export interface Lockfile {
+  readonly version: string;
+  readonly directRequirements: ReadonlyMap<
+    string,
+    readonly DirectRequirement[]
+  >;
+  readonly transitiveParents: ReadonlyMap<string, readonly ParentRequirement[]>;
+}
+
+export interface SnapshotKey {
+  readonly name: string;
+  readonly version: string;
+}
+
+export function parseSnapshotKey(key: string): SnapshotKey | null {
+  // Strip pnpm peer-dependency decorations: "pkg@1.0.0(peer@2.0.0)" → "pkg@1.0.0"
+  const peerStart = key.indexOf("(");
+  const base = peerStart === -1 ? key : key.slice(0, peerStart);
+
+  // Scoped names start with "@", so use lastIndexOf to find the version separator.
+  const lastAt = base.lastIndexOf("@");
+  if (lastAt <= 0) {
+    return null;
+  }
+  const name = base.slice(0, lastAt);
+  const version = base.slice(lastAt + 1);
+  if (name.length === 0 || version.length === 0) {
+    return null;
+  }
+  return { name, version };
+}
+
+export function parseResolvedVersion(value: string): string {
+  // Strip pnpm peer-dependency decorations from importer "version" fields.
+  const peerStart = value.indexOf("(");
+  return peerStart === -1 ? value : value.slice(0, peerStart);
+}
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function appendToMultiMap<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const existing = map.get(key);
+  if (existing === undefined) {
+    map.set(key, [value]);
+  } else {
+    existing.push(value);
+  }
+}
+
+function extractDirectRequirements(
+  raw: Record<string, unknown>,
+): ReadonlyMap<string, readonly DirectRequirement[]> {
+  const map = new Map<string, DirectRequirement[]>();
+  const importers = raw.importers;
+  if (!isObject(importers)) {
+    return map;
+  }
+  for (const [importerKey, importerValue] of Object.entries(importers)) {
+    if (!isObject(importerValue)) {
+      continue;
+    }
+    for (const depType of DIRECT_DEP_FIELDS) {
+      const deps = importerValue[depType];
+      if (!isObject(deps)) {
+        continue;
+      }
+      for (const [pkgName, depValue] of Object.entries(deps)) {
+        if (!isObject(depValue)) {
+          continue;
+        }
+        const specifier = depValue.specifier;
+        const version = depValue.version;
+        if (typeof specifier !== "string" || typeof version !== "string") {
+          continue;
+        }
+        appendToMultiMap(map, pkgName, {
+          importerKey,
+          depType,
+          specifier,
+          resolvedVersion: parseResolvedVersion(version),
+        });
+      }
+    }
+  }
+  return map;
+}
+
+function extractTransitiveParents(
+  raw: Record<string, unknown>,
+): ReadonlyMap<string, readonly ParentRequirement[]> {
+  const map = new Map<string, ParentRequirement[]>();
+  const snapshots = raw.snapshots;
+  if (!isObject(snapshots)) {
+    return map;
+  }
+  for (const [parentKey, snapshotValue] of Object.entries(snapshots)) {
+    if (!isObject(snapshotValue)) {
+      continue;
+    }
+    for (const depField of ["dependencies", "optionalDependencies"] as const) {
+      const deps = snapshotValue[depField];
+      if (!isObject(deps)) {
+        continue;
+      }
+      for (const [target, resolvedRaw] of Object.entries(deps)) {
+        if (typeof resolvedRaw !== "string") {
+          continue;
+        }
+        appendToMultiMap(map, target, {
+          parentKey,
+          resolvedVersion: parseResolvedVersion(resolvedRaw),
+        });
+      }
+    }
+  }
+  return map;
+}
+
+export function parseLockfile(content: string): Lockfile {
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(content);
+  } catch (e) {
+    throw new MalformedLockfileError(
+      e instanceof Error ? e.message : "yaml parse error",
+    );
+  }
+  if (!isObject(parsed)) {
+    throw new MalformedLockfileError("root must be an object");
+  }
+  const versionRaw = parsed.lockfileVersion;
+  const version = typeof versionRaw === "string" ? versionRaw : null;
+  if (version !== SUPPORTED_LOCKFILE_VERSION) {
+    throw new UnsupportedLockfileVersionError(version);
+  }
+  return {
+    version,
+    directRequirements: extractDirectRequirements(parsed),
+    transitiveParents: extractTransitiveParents(parsed),
+  };
+}

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,0 +1,95 @@
+import { parse as parseYaml } from "yaml";
+
+export type WorkspaceFilename = "pnpm-workspace.yaml" | "aube-workspace.yaml";
+export type PackageJsonContainer =
+  | "package.json:pnpm.overrides"
+  | "package.json:overrides";
+export type OverrideSource = PackageJsonContainer | WorkspaceFilename;
+
+export interface Override {
+  readonly key: string;
+  readonly spec: string;
+  readonly source: OverrideSource;
+}
+
+export class MalformedManifestError extends Error {
+  override readonly name = "MalformedManifestError";
+  constructor(message: string) {
+    super(`malformed manifest: ${message}`);
+  }
+}
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function collectOverridesFromMap(
+  obj: Record<string, unknown>,
+  source: OverrideSource,
+): Override[] {
+  const result: Override[] = [];
+  for (const [key, spec] of Object.entries(obj)) {
+    if (typeof spec === "string") {
+      result.push({ key, spec, source });
+    }
+  }
+  return result;
+}
+
+export function parsePackageJsonOverrides(
+  content: string,
+): readonly Override[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (e) {
+    throw new MalformedManifestError(
+      e instanceof Error ? e.message : "json parse error",
+    );
+  }
+  if (!isObject(parsed)) {
+    return [];
+  }
+  const result: Override[] = [];
+  const pnpmField = parsed.pnpm;
+  if (isObject(pnpmField)) {
+    const pnpmOverrides = pnpmField.overrides;
+    if (isObject(pnpmOverrides)) {
+      result.push(
+        ...collectOverridesFromMap(
+          pnpmOverrides,
+          "package.json:pnpm.overrides",
+        ),
+      );
+    }
+  }
+  const topLevelOverrides = parsed.overrides;
+  if (isObject(topLevelOverrides)) {
+    result.push(
+      ...collectOverridesFromMap(topLevelOverrides, "package.json:overrides"),
+    );
+  }
+  return result;
+}
+
+export function parseWorkspaceOverrides(
+  content: string,
+  source: WorkspaceFilename,
+): readonly Override[] {
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(content);
+  } catch (e) {
+    throw new MalformedManifestError(
+      e instanceof Error ? e.message : "yaml parse error",
+    );
+  }
+  if (!isObject(parsed)) {
+    return [];
+  }
+  const overrides = parsed.overrides;
+  if (!isObject(overrides)) {
+    return [];
+  }
+  return collectOverridesFromMap(overrides, source);
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,0 +1,120 @@
+import {
+  categorize,
+  classify,
+  type Result,
+  type SkipReason,
+} from "./analyze.ts";
+import { type Lockfile, parseSnapshotKey } from "./lockfile.ts";
+import type { Override } from "./manifest.ts";
+import type { PackageMetadata } from "./registry.ts";
+import { computeNaturalResolution } from "./resolve.ts";
+
+export interface AuditEntry {
+  readonly override: Override;
+  readonly result: Result;
+}
+
+function skipReasonToValue(reason: SkipReason): string {
+  switch (reason) {
+    case "nested-key":
+      return "(nested key)";
+    case "protocol-spec":
+      return "(protocol spec)";
+    case "non-lower-bound":
+      return "(non-lower-bound)";
+  }
+}
+
+export function gatherSpecsForTarget(
+  target: string,
+  lockfile: Lockfile,
+  registryData: ReadonlyMap<string, PackageMetadata>,
+): readonly string[] {
+  const specs: string[] = [];
+  const direct = lockfile.directRequirements.get(target);
+  if (direct !== undefined) {
+    for (const req of direct) {
+      specs.push(req.specifier);
+    }
+  }
+  const parents = lockfile.transitiveParents.get(target);
+  if (parents !== undefined) {
+    for (const parent of parents) {
+      const parsed = parseSnapshotKey(parent.parentKey);
+      if (parsed === null) {
+        continue;
+      }
+      const meta = registryData.get(parsed.name);
+      if (meta === undefined) {
+        continue;
+      }
+      const versionMeta = meta.versions.get(parsed.version);
+      if (versionMeta === undefined) {
+        continue;
+      }
+      const spec = versionMeta.dependencies.get(target);
+      if (spec === undefined) {
+        continue;
+      }
+      specs.push(spec);
+    }
+  }
+  return specs;
+}
+
+export function evaluateOverride(
+  override: Override,
+  lockfile: Lockfile,
+  registryData: ReadonlyMap<string, PackageMetadata>,
+): Result {
+  const cat = categorize(override.key, override.spec);
+  if (cat.kind === "skip") {
+    return { status: "skip", value: skipReasonToValue(cat.reason) };
+  }
+  const specs = gatherSpecsForTarget(override.key, lockfile, registryData);
+  if (specs.length === 0) {
+    return { status: "prune", value: "(unused)" };
+  }
+  const targetMeta = registryData.get(override.key);
+  if (targetMeta === undefined) {
+    return { status: "error", value: "(registry miss)" };
+  }
+  const candidates = Array.from(targetMeta.versions.keys());
+  const natural = computeNaturalResolution(specs, candidates);
+  return classify(override.spec, natural);
+}
+
+export function collectPackagesForOverride(
+  override: Override,
+  lockfile: Lockfile,
+): readonly string[] {
+  const cat = categorize(override.key, override.spec);
+  if (cat.kind !== "target") {
+    return [];
+  }
+  const needed = new Set<string>();
+  needed.add(override.key);
+  const parents = lockfile.transitiveParents.get(override.key);
+  if (parents !== undefined) {
+    for (const parent of parents) {
+      const parsed = parseSnapshotKey(parent.parentKey);
+      if (parsed !== null) {
+        needed.add(parsed.name);
+      }
+    }
+  }
+  return Array.from(needed);
+}
+
+export function collectNeededRegistryPackages(
+  overrides: readonly Override[],
+  lockfile: Lockfile,
+): readonly string[] {
+  const needed = new Set<string>();
+  for (const override of overrides) {
+    for (const name of collectPackagesForOverride(override, lockfile)) {
+      needed.add(name);
+    }
+  }
+  return Array.from(needed);
+}

--- a/src/registry-fetch.ts
+++ b/src/registry-fetch.ts
@@ -1,0 +1,58 @@
+import { type PackageMetadata, parsePackageMetadata } from "./registry.ts";
+
+export interface RegistryClient {
+  fetchPackage(name: string): Promise<PackageMetadata>;
+}
+
+export interface RegistryClientOptions {
+  readonly baseUrl?: string;
+}
+
+export class RegistryFetchError extends Error {
+  override readonly name = "RegistryFetchError";
+  readonly packageName: string;
+  constructor(packageName: string, cause: unknown) {
+    super(
+      `failed to fetch '${packageName}' from registry: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+    this.packageName = packageName;
+  }
+}
+
+function encodePackageName(name: string): string {
+  return name.split("/").map(encodeURIComponent).join("/");
+}
+
+export function createNpmRegistryClient(
+  options: RegistryClientOptions = {},
+): RegistryClient {
+  const baseUrl = options.baseUrl ?? "https://registry.npmjs.org";
+  const cache = new Map<string, Promise<PackageMetadata>>();
+  return {
+    fetchPackage(name: string): Promise<PackageMetadata> {
+      const cached = cache.get(name);
+      if (cached !== undefined) {
+        return cached;
+      }
+      const promise = (async () => {
+        const url = `${baseUrl}/${encodePackageName(name)}`;
+        let response: Response;
+        try {
+          response = await fetch(url);
+        } catch (cause) {
+          throw new RegistryFetchError(name, cause);
+        }
+        if (!response.ok) {
+          throw new RegistryFetchError(
+            name,
+            new Error(`HTTP ${response.status}`),
+          );
+        }
+        const raw: unknown = await response.json();
+        return parsePackageMetadata(raw, name);
+      })();
+      cache.set(name, promise);
+      return promise;
+    },
+  };
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,73 @@
+export interface PackageVersionMeta {
+  readonly version: string;
+  /** Merged map of dependencies + peerDependencies + optionalDependencies. */
+  readonly dependencies: ReadonlyMap<string, string>;
+}
+
+export interface PackageMetadata {
+  readonly name: string;
+  readonly versions: ReadonlyMap<string, PackageVersionMeta>;
+}
+
+export class MalformedRegistryResponseError extends Error {
+  override readonly name = "MalformedRegistryResponseError";
+  constructor(message: string) {
+    super(`malformed registry response: ${message}`);
+  }
+}
+
+const DEP_FIELDS = [
+  "dependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function mergeDepFields(
+  versionRecord: Record<string, unknown>,
+): ReadonlyMap<string, string> {
+  const merged = new Map<string, string>();
+  for (const field of DEP_FIELDS) {
+    const deps = versionRecord[field];
+    if (!isObject(deps)) {
+      continue;
+    }
+    for (const [depName, depSpec] of Object.entries(deps)) {
+      if (typeof depSpec !== "string") {
+        continue;
+      }
+      // First write wins so dependencies takes precedence over peers/optional.
+      if (!merged.has(depName)) {
+        merged.set(depName, depSpec);
+      }
+    }
+  }
+  return merged;
+}
+
+export function parsePackageMetadata(
+  raw: unknown,
+  name: string,
+): PackageMetadata {
+  if (!isObject(raw)) {
+    throw new MalformedRegistryResponseError("root must be an object");
+  }
+  const versionsRaw = raw.versions;
+  if (!isObject(versionsRaw)) {
+    throw new MalformedRegistryResponseError("'versions' field is missing");
+  }
+  const versions = new Map<string, PackageVersionMeta>();
+  for (const [version, versionData] of Object.entries(versionsRaw)) {
+    if (!isObject(versionData)) {
+      continue;
+    }
+    versions.set(version, {
+      version,
+      dependencies: mergeDepFields(versionData),
+    });
+  }
+  return { name, versions };
+}

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,0 +1,24 @@
+import { maxSatisfying, satisfies } from "semver";
+
+/**
+ * Given parent dependency specs and a list of candidate published versions,
+ * compute the highest version that satisfies all parent specs simultaneously.
+ *
+ * Returns null when there are no parent specs, no candidates, or no version
+ * satisfies the intersection. Pre-releases are ignored unless they fall inside
+ * a parent spec that explicitly opts them in.
+ */
+export function computeNaturalResolution(
+  parentSpecs: readonly string[],
+  candidateVersions: readonly string[],
+): string | null {
+  if (parentSpecs.length === 0 || candidateVersions.length === 0) {
+    return null;
+  }
+  const filtered = candidateVersions.filter((version) =>
+    parentSpecs.every((spec) =>
+      satisfies(version, spec, { includePrerelease: false }),
+    ),
+  );
+  return maxSatisfying(filtered, ">=0.0.0", { includePrerelease: false });
+}

--- a/src/rewrite.ts
+++ b/src/rewrite.ts
@@ -1,0 +1,80 @@
+import { isMap, parseDocument } from "yaml";
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function detectJsonIndent(content: string): string | number {
+  const match = content.match(/^([\t ]+)/m);
+  if (match !== null) {
+    return match[1] ?? 2;
+  }
+  return 2;
+}
+
+export interface PackageJsonRemoval {
+  readonly fromPnpmOverrides: readonly string[];
+  readonly fromTopLevelOverrides: readonly string[];
+}
+
+export function removeFromPackageJson(
+  content: string,
+  removal: PackageJsonRemoval,
+): string {
+  if (
+    removal.fromPnpmOverrides.length === 0 &&
+    removal.fromTopLevelOverrides.length === 0
+  ) {
+    return content;
+  }
+  const parsed: unknown = JSON.parse(content);
+  if (!isObject(parsed)) {
+    return content;
+  }
+  let modified = false;
+  if (removal.fromPnpmOverrides.length > 0) {
+    const pnpmField = parsed.pnpm;
+    if (isObject(pnpmField)) {
+      const overrides = pnpmField.overrides;
+      if (isObject(overrides)) {
+        for (const key of removal.fromPnpmOverrides) {
+          delete overrides[key];
+        }
+        modified = true;
+      }
+    }
+  }
+  if (removal.fromTopLevelOverrides.length > 0) {
+    const overrides = parsed.overrides;
+    if (isObject(overrides)) {
+      for (const key of removal.fromTopLevelOverrides) {
+        delete overrides[key];
+      }
+      modified = true;
+    }
+  }
+  if (!modified) {
+    return content;
+  }
+  const indent = detectJsonIndent(content);
+  const trailingNewline = content.endsWith("\n") ? "\n" : "";
+  return JSON.stringify(parsed, null, indent) + trailingNewline;
+}
+
+export function removeFromWorkspaceYaml(
+  content: string,
+  keys: readonly string[],
+): string {
+  if (keys.length === 0) {
+    return content;
+  }
+  const doc = parseDocument(content);
+  const overridesNode = doc.get("overrides", true);
+  if (!isMap(overridesNode)) {
+    return content;
+  }
+  for (const key of keys) {
+    overridesNode.delete(key);
+  }
+  return doc.toString();
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,53 @@
+import { parseArgs } from "./args.ts";
+import { formatHelp, formatVersion } from "./format.ts";
+
+export interface SyncOutcome {
+  readonly kind: "sync";
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface AuditRequest {
+  readonly kind: "audit";
+  readonly path: string;
+  readonly fix: boolean;
+}
+
+export type RunDecision = SyncOutcome | AuditRequest;
+
+export function decideRun(
+  argv: readonly string[],
+  version: string,
+): RunDecision {
+  const parsed = parseArgs(argv);
+  switch (parsed.kind) {
+    case "version":
+      return {
+        kind: "sync",
+        exitCode: 0,
+        stdout: formatVersion(version),
+        stderr: "",
+      };
+    case "help":
+      return {
+        kind: "sync",
+        exitCode: 0,
+        stdout: formatHelp(),
+        stderr: "",
+      };
+    case "error":
+      return {
+        kind: "sync",
+        exitCode: 2,
+        stdout: "",
+        stderr: `error: ${parsed.message}\n`,
+      };
+    case "audit":
+      return {
+        kind: "audit",
+        path: parsed.path,
+        fix: parsed.fix,
+      };
+  }
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,3 @@
+import pkg from "../package.json" with { type: "json" };
+
+export const VERSION: string = pkg.version;

--- a/tests/analyze.test.ts
+++ b/tests/analyze.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "bun:test";
+import {
+  categorize,
+  classify,
+  hasProtocolPrefix,
+  isNestedKey,
+  isPureLowerBound,
+} from "../src/analyze.ts";
+
+describe("isPureLowerBound", () => {
+  it("accepts >=", () => {
+    expect(isPureLowerBound(">=1.0.0")).toBe(true);
+  });
+
+  it("accepts >", () => {
+    expect(isPureLowerBound(">1.0.0")).toBe(true);
+  });
+
+  it("accepts OR of pure lower bounds", () => {
+    expect(isPureLowerBound(">=1.0.0 || >=2.0.0")).toBe(true);
+  });
+
+  it("rejects exact version", () => {
+    expect(isPureLowerBound("1.0.0")).toBe(false);
+  });
+
+  it("rejects caret range", () => {
+    expect(isPureLowerBound("^1.0.0")).toBe(false);
+  });
+
+  it("rejects tilde range", () => {
+    expect(isPureLowerBound("~1.0.0")).toBe(false);
+  });
+
+  it("rejects bounded range", () => {
+    expect(isPureLowerBound(">=1.0.0 <2.0.0")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isPureLowerBound("")).toBe(false);
+  });
+
+  it("rejects malformed spec", () => {
+    expect(isPureLowerBound("not-a-version")).toBe(false);
+  });
+
+  it("rejects bare wildcard", () => {
+    // "*" expands to >=0.0.0 with operator "" — we still want it filtered
+    // because it carries no meaningful lower bound.
+    expect(isPureLowerBound("*")).toBe(false);
+  });
+});
+
+describe("isNestedKey", () => {
+  it("recognizes parent>child syntax", () => {
+    expect(isNestedKey("foo>bar")).toBe(true);
+  });
+
+  it("treats flat name as not nested", () => {
+    expect(isNestedKey("foo")).toBe(false);
+  });
+
+  it("treats scoped flat name as not nested", () => {
+    expect(isNestedKey("@scope/foo")).toBe(false);
+  });
+});
+
+describe("hasProtocolPrefix", () => {
+  it("detects catalog:", () => {
+    expect(hasProtocolPrefix("catalog:default")).toBe(true);
+  });
+
+  it("detects workspace:", () => {
+    expect(hasProtocolPrefix("workspace:*")).toBe(true);
+  });
+
+  it("detects file:", () => {
+    expect(hasProtocolPrefix("file:./local")).toBe(true);
+  });
+
+  it("detects link:", () => {
+    expect(hasProtocolPrefix("link:./local")).toBe(true);
+  });
+
+  it("detects portal:", () => {
+    expect(hasProtocolPrefix("portal:./local")).toBe(true);
+  });
+
+  it("detects npm:", () => {
+    expect(hasProtocolPrefix("npm:foo@1.0.0")).toBe(true);
+  });
+
+  it("detects github:", () => {
+    expect(hasProtocolPrefix("github:user/repo")).toBe(true);
+  });
+
+  it("detects git:", () => {
+    expect(hasProtocolPrefix("git:foo")).toBe(true);
+  });
+
+  it("detects git+", () => {
+    expect(hasProtocolPrefix("git+https://example.com/repo.git")).toBe(true);
+  });
+
+  it("detects http:", () => {
+    expect(hasProtocolPrefix("http://example.com/foo.tgz")).toBe(true);
+  });
+
+  it("detects https:", () => {
+    expect(hasProtocolPrefix("https://example.com/foo.tgz")).toBe(true);
+  });
+
+  it("ignores plain semver", () => {
+    expect(hasProtocolPrefix("1.0.0")).toBe(false);
+    expect(hasProtocolPrefix(">=1.0.0")).toBe(false);
+    expect(hasProtocolPrefix("^1.0.0")).toBe(false);
+  });
+});
+
+describe("categorize", () => {
+  it("targets a pure lower bound on a flat key", () => {
+    expect(categorize("foo", ">=1.0.0")).toEqual({
+      kind: "target",
+      spec: ">=1.0.0",
+    });
+  });
+
+  it("skips nested keys", () => {
+    expect(categorize("foo>bar", ">=1.0.0")).toEqual({
+      kind: "skip",
+      reason: "nested-key",
+    });
+  });
+
+  it("skips protocol specs", () => {
+    expect(categorize("foo", "catalog:default")).toEqual({
+      kind: "skip",
+      reason: "protocol-spec",
+    });
+  });
+
+  it("skips exact pins", () => {
+    expect(categorize("foo", "1.0.0")).toEqual({
+      kind: "skip",
+      reason: "non-lower-bound",
+    });
+  });
+
+  it("skips caret ranges", () => {
+    expect(categorize("foo", "^1.0.0")).toEqual({
+      kind: "skip",
+      reason: "non-lower-bound",
+    });
+  });
+
+  it("nested-key takes precedence over protocol", () => {
+    expect(categorize("foo>bar", "workspace:*")).toEqual({
+      kind: "skip",
+      reason: "nested-key",
+    });
+  });
+
+  it("protocol takes precedence over non-lower-bound check", () => {
+    // "catalog:default" would also fail isPureLowerBound, but the protocol
+    // reason is more informative.
+    expect(categorize("foo", "catalog:default")).toEqual({
+      kind: "skip",
+      reason: "protocol-spec",
+    });
+  });
+});
+
+describe("classify", () => {
+  it("prunes when nothing depends on the package (resolved is null)", () => {
+    expect(classify(">=1.0.0", null)).toEqual({
+      status: "prune",
+      value: "(unused)",
+    });
+  });
+
+  it("prunes when resolved version satisfies the lower bound", () => {
+    expect(classify(">=1.0.0", "2.0.0")).toEqual({
+      status: "prune",
+      value: "2.0.0",
+    });
+  });
+
+  it("prunes at exact lower bound", () => {
+    expect(classify(">=2.0.0", "2.0.0")).toEqual({
+      status: "prune",
+      value: "2.0.0",
+    });
+  });
+
+  it("keeps when resolved version is below the bound", () => {
+    expect(classify(">=2.0.0", "1.0.0")).toEqual({
+      status: "keep",
+      value: "1.0.0",
+    });
+  });
+
+  it("keeps when resolved equals the strict-greater bound", () => {
+    expect(classify(">2.0.0", "2.0.0")).toEqual({
+      status: "keep",
+      value: "2.0.0",
+    });
+  });
+});

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_PACKAGE_JSON_PATH, parseArgs } from "../src/args.ts";
+
+describe("parseArgs", () => {
+  it("returns audit with default path when given no args", () => {
+    expect(parseArgs([])).toEqual({
+      kind: "audit",
+      path: DEFAULT_PACKAGE_JSON_PATH,
+      fix: false,
+    });
+  });
+
+  it("recognizes -V as a version request", () => {
+    expect(parseArgs(["-V"])).toEqual({ kind: "version" });
+  });
+
+  it("recognizes --version as a version request", () => {
+    expect(parseArgs(["--version"])).toEqual({ kind: "version" });
+  });
+
+  it("recognizes -h as a help request", () => {
+    expect(parseArgs(["-h"])).toEqual({ kind: "help" });
+  });
+
+  it("recognizes --help as a help request", () => {
+    expect(parseArgs(["--help"])).toEqual({ kind: "help" });
+  });
+
+  it("treats version flag as taking precedence over fix and positional", () => {
+    expect(parseArgs(["--version", "--fix", "foo"])).toEqual({
+      kind: "version",
+    });
+  });
+
+  it("treats help flag as taking precedence over fix and positional", () => {
+    expect(parseArgs(["--help", "foo"])).toEqual({ kind: "help" });
+  });
+
+  it("captures --fix as audit with fix=true and default path", () => {
+    expect(parseArgs(["--fix"])).toEqual({
+      kind: "audit",
+      path: DEFAULT_PACKAGE_JSON_PATH,
+      fix: true,
+    });
+  });
+
+  it("captures positional path", () => {
+    expect(parseArgs(["path/to/package.json"])).toEqual({
+      kind: "audit",
+      path: "path/to/package.json",
+      fix: false,
+    });
+  });
+
+  it("captures positional path together with --fix", () => {
+    expect(parseArgs(["path/to/package.json", "--fix"])).toEqual({
+      kind: "audit",
+      path: "path/to/package.json",
+      fix: true,
+    });
+  });
+
+  it("captures --fix before the positional path", () => {
+    expect(parseArgs(["--fix", "path/to/package.json"])).toEqual({
+      kind: "audit",
+      path: "path/to/package.json",
+      fix: true,
+    });
+  });
+
+  it("returns error when given multiple positional arguments", () => {
+    const result = parseArgs(["a", "b"]);
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("at most one");
+    }
+  });
+
+  it("returns error when given an unknown flag", () => {
+    const result = parseArgs(["--unknown"]);
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "bun:test";
+import {
+  entryDisplay,
+  entryWidth,
+  formatHelp,
+  formatLine,
+  formatSectionHeader,
+  formatSummary,
+  formatVersion,
+  LABELS,
+  SOURCE_ORDER,
+} from "../src/format.ts";
+import type { Override } from "../src/manifest.ts";
+import type { AuditEntry } from "../src/pipeline.ts";
+
+const PKG: (key: string, spec: string) => Override = (key, spec) => ({
+  key,
+  spec,
+  source: "package.json:pnpm.overrides",
+});
+
+describe("LABELS", () => {
+  it("covers all statuses with uniform-width labels", () => {
+    expect(Object.keys(LABELS).sort()).toEqual([
+      "error",
+      "keep",
+      "prune",
+      "skip",
+    ]);
+    const widths = new Set(Object.values(LABELS).map((l) => l.length));
+    expect(widths.size).toBe(1);
+  });
+});
+
+describe("SOURCE_ORDER", () => {
+  it("places top-level overrides first, then pnpm.overrides, then workspace yamls", () => {
+    expect(SOURCE_ORDER).toEqual([
+      "package.json:overrides",
+      "package.json:pnpm.overrides",
+      "pnpm-workspace.yaml",
+      "aube-workspace.yaml",
+    ]);
+  });
+});
+
+describe("entryDisplay", () => {
+  it("joins key and spec with a space", () => {
+    expect(entryDisplay(PKG("@xmldom/xmldom", ">=0.9.10"))).toBe(
+      "@xmldom/xmldom >=0.9.10",
+    );
+  });
+});
+
+describe("entryWidth", () => {
+  it("returns 0 for empty list", () => {
+    expect(entryWidth([])).toBe(0);
+  });
+
+  it("returns the max display length", () => {
+    expect(
+      entryWidth([
+        PKG("a", ">=1.0.0"),
+        PKG("longer-name", ">=1.0.0"),
+        PKG("b", ">=1.0.0"),
+      ]),
+    ).toBe("longer-name >=1.0.0".length);
+  });
+});
+
+describe("formatSectionHeader", () => {
+  it("uses 'entry' for count of 1", () => {
+    expect(formatSectionHeader("package.json:pnpm.overrides", 1)).toBe(
+      "=== package.json:pnpm.overrides (1 entry) ===\n",
+    );
+  });
+
+  it("uses 'entries' for plural counts", () => {
+    expect(formatSectionHeader("pnpm-workspace.yaml", 3)).toBe(
+      "=== pnpm-workspace.yaml (3 entries) ===\n",
+    );
+  });
+});
+
+describe("formatLine", () => {
+  it("renders label, padded display, and value", () => {
+    const entry: AuditEntry = {
+      override: PKG("foo", ">=1.0.0"),
+      result: { status: "prune", value: "1.5.0" },
+    };
+    expect(formatLine(entry, 20)).toBe("[PRUNE] foo >=1.0.0           1.5.0\n");
+  });
+
+  it("uses the appropriate label for each status", () => {
+    const make = (status: "prune" | "keep" | "skip" | "error"): AuditEntry => ({
+      override: PKG("foo", ">=1.0.0"),
+      result: { status, value: "x" },
+    });
+    expect(formatLine(make("prune"), 11)).toContain("[PRUNE]");
+    expect(formatLine(make("keep"), 11)).toContain("[KEEP] ");
+    expect(formatLine(make("skip"), 11)).toContain("[SKIP] ");
+    expect(formatLine(make("error"), 11)).toContain("[ERROR]");
+  });
+});
+
+describe("formatSummary", () => {
+  it("clean (no prunable, not fixed)", () => {
+    expect(formatSummary({ prunableCount: 0, fixed: false })).toBe(
+      "No prunable entries found.\n",
+    );
+  });
+
+  it("clean after fix (no prunable, fixed)", () => {
+    expect(formatSummary({ prunableCount: 0, fixed: true })).toBe(
+      "No prunable entries found.\n",
+    );
+  });
+
+  it("prunable found, not fixed", () => {
+    expect(formatSummary({ prunableCount: 2, fixed: false })).toBe(
+      "Run with --fix to prune entries marked [PRUNE].\n",
+    );
+  });
+
+  it("prunable fixed (singular)", () => {
+    expect(formatSummary({ prunableCount: 1, fixed: true })).toBe(
+      "Pruned 1 entry.\n",
+    );
+  });
+
+  it("prunable fixed (plural)", () => {
+    expect(formatSummary({ prunableCount: 5, fixed: true })).toBe(
+      "Pruned 5 entries.\n",
+    );
+  });
+});
+
+describe("formatVersion", () => {
+  it("prints program name and version with trailing newline", () => {
+    expect(formatVersion("1.2.3")).toBe("pnpm-override-prune 1.2.3\n");
+  });
+});
+
+describe("formatHelp", () => {
+  it("includes usage line and key flags", () => {
+    const text = formatHelp();
+    expect(text).toContain("Usage: pnpm-override-prune");
+    expect(text).toContain("--fix");
+    expect(text).toContain("-V, --version");
+    expect(text).toContain("-h, --help");
+  });
+});

--- a/tests/lockfile.test.ts
+++ b/tests/lockfile.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from "bun:test";
+import {
+  MalformedLockfileError,
+  parseLockfile,
+  parseResolvedVersion,
+  parseSnapshotKey,
+  UnsupportedLockfileVersionError,
+} from "../src/lockfile.ts";
+
+describe("parseSnapshotKey", () => {
+  it("parses unscoped name@version", () => {
+    expect(parseSnapshotKey("speech-rule-engine@4.1.4")).toEqual({
+      name: "speech-rule-engine",
+      version: "4.1.4",
+    });
+  });
+
+  it("parses scoped name@version", () => {
+    expect(parseSnapshotKey("@xmldom/xmldom@0.9.10")).toEqual({
+      name: "@xmldom/xmldom",
+      version: "0.9.10",
+    });
+  });
+
+  it("strips peer dependency decorations", () => {
+    expect(parseSnapshotKey("foo@1.0.0(bar@2.0.0)")).toEqual({
+      name: "foo",
+      version: "1.0.0",
+    });
+  });
+
+  it("strips peer decorations on scoped names", () => {
+    expect(parseSnapshotKey("@a/b@1.0.0(c@2.0.0)(d@3.0.0)")).toEqual({
+      name: "@a/b",
+      version: "1.0.0",
+    });
+  });
+
+  it("rejects keys without an @ separator", () => {
+    expect(parseSnapshotKey("foo")).toBeNull();
+  });
+
+  it("rejects keys whose only @ is a leading scope marker", () => {
+    expect(parseSnapshotKey("@scope")).toBeNull();
+  });
+
+  it("rejects empty string", () => {
+    expect(parseSnapshotKey("")).toBeNull();
+  });
+
+  it("rejects keys with empty version", () => {
+    expect(parseSnapshotKey("foo@")).toBeNull();
+  });
+});
+
+describe("parseResolvedVersion", () => {
+  it("returns plain version unchanged", () => {
+    expect(parseResolvedVersion("1.0.0")).toBe("1.0.0");
+  });
+
+  it("strips single peer decoration", () => {
+    expect(parseResolvedVersion("1.0.0(peer@2.0.0)")).toBe("1.0.0");
+  });
+
+  it("strips multiple peer decorations", () => {
+    expect(parseResolvedVersion("1.0.0(peer@2.0.0)(other@3.0.0)")).toBe(
+      "1.0.0",
+    );
+  });
+});
+
+const VALID_LOCKFILE = `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+
+importers:
+  .:
+    dependencies:
+      semver:
+        specifier: ^7.0.0
+        version: 7.7.4
+      yaml:
+        specifier: 2.8.3
+        version: 2.8.3
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+packages:
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-foo}
+
+snapshots:
+  '@xmldom/xmldom@0.9.10': {}
+
+  speech-rule-engine@4.1.4:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
+      commander: 13.1.0
+    optionalDependencies:
+      optionaldep: 1.2.3
+
+  another-parent@2.0.0:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
+`;
+
+describe("parseLockfile", () => {
+  it("parses a valid v9.0 lockfile", () => {
+    const lf = parseLockfile(VALID_LOCKFILE);
+    expect(lf.version).toBe("9.0");
+  });
+
+  it("collects direct requirements with specifier and resolved version", () => {
+    const lf = parseLockfile(VALID_LOCKFILE);
+    const semver = lf.directRequirements.get("semver");
+    expect(semver).toEqual([
+      {
+        importerKey: ".",
+        depType: "dependencies",
+        specifier: "^7.0.0",
+        resolvedVersion: "7.7.4",
+      },
+    ]);
+    const ts = lf.directRequirements.get("typescript");
+    expect(ts).toEqual([
+      {
+        importerKey: ".",
+        depType: "devDependencies",
+        specifier: "6.0.3",
+        resolvedVersion: "6.0.3",
+      },
+    ]);
+  });
+
+  it("collects transitive parents from snapshots dependencies", () => {
+    const lf = parseLockfile(VALID_LOCKFILE);
+    const parents = lf.transitiveParents.get("@xmldom/xmldom");
+    expect(parents).toEqual([
+      { parentKey: "speech-rule-engine@4.1.4", resolvedVersion: "0.9.10" },
+      { parentKey: "another-parent@2.0.0", resolvedVersion: "0.9.10" },
+    ]);
+  });
+
+  it("collects optional dependencies as transitive parents too", () => {
+    const lf = parseLockfile(VALID_LOCKFILE);
+    const parents = lf.transitiveParents.get("optionaldep");
+    expect(parents).toEqual([
+      { parentKey: "speech-rule-engine@4.1.4", resolvedVersion: "1.2.3" },
+    ]);
+  });
+
+  it("strips peer decorations from importer resolved version", () => {
+    const lockfile = `lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 1.0.0
+        version: 1.0.0(peer@2.0.0)
+
+snapshots: {}
+`;
+    const lf = parseLockfile(lockfile);
+    expect(lf.directRequirements.get("foo")).toEqual([
+      {
+        importerKey: ".",
+        depType: "dependencies",
+        specifier: "1.0.0",
+        resolvedVersion: "1.0.0",
+      },
+    ]);
+  });
+
+  it("throws UnsupportedLockfileVersionError on missing version", () => {
+    const lockfile = "settings: {}\n";
+    let thrown: unknown;
+    try {
+      parseLockfile(lockfile);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(UnsupportedLockfileVersionError);
+    if (thrown instanceof UnsupportedLockfileVersionError) {
+      expect(thrown.found).toBeNull();
+    }
+  });
+
+  it("throws UnsupportedLockfileVersionError on legacy version", () => {
+    const lockfile = "lockfileVersion: '6.0'\n";
+    let thrown: unknown;
+    try {
+      parseLockfile(lockfile);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(UnsupportedLockfileVersionError);
+    if (thrown instanceof UnsupportedLockfileVersionError) {
+      expect(thrown.found).toBe("6.0");
+    }
+  });
+
+  it("throws UnsupportedLockfileVersionError when version is not a string", () => {
+    const lockfile = "lockfileVersion: 9.0\n";
+    let thrown: unknown;
+    try {
+      parseLockfile(lockfile);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(UnsupportedLockfileVersionError);
+    if (thrown instanceof UnsupportedLockfileVersionError) {
+      expect(thrown.found).toBeNull();
+    }
+  });
+
+  it("throws MalformedLockfileError on invalid YAML", () => {
+    expect(() => parseLockfile(": : :\n  bad:\n indent")).toThrow(
+      MalformedLockfileError,
+    );
+  });
+
+  it("throws MalformedLockfileError when root is not a mapping", () => {
+    expect(() => parseLockfile("- a\n- b\n")).toThrow(MalformedLockfileError);
+  });
+
+  it("returns empty maps when importers and snapshots are absent", () => {
+    const lf = parseLockfile("lockfileVersion: '9.0'\n");
+    expect(lf.directRequirements.size).toBe(0);
+    expect(lf.transitiveParents.size).toBe(0);
+  });
+
+  it("ignores importers entries that are not mappings", () => {
+    const lockfile = `lockfileVersion: '9.0'
+importers:
+  .: invalid-string-instead-of-map
+`;
+    const lf = parseLockfile(lockfile);
+    expect(lf.directRequirements.size).toBe(0);
+  });
+
+  it("ignores dep-type fields whose value is not a mapping", () => {
+    const lockfile = `lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies: not-a-map
+`;
+    const lf = parseLockfile(lockfile);
+    expect(lf.directRequirements.size).toBe(0);
+  });
+
+  it("ignores dep entries that are not mappings", () => {
+    const lockfile = `lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo: just-a-string
+`;
+    const lf = parseLockfile(lockfile);
+    expect(lf.directRequirements.size).toBe(0);
+  });
+
+  it("ignores dep entries with non-string specifier or version", () => {
+    const lockfile = `lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 1.0.0
+        version: 1
+      bar:
+        specifier: 2
+        version: 2.0.0
+`;
+    const lf = parseLockfile(lockfile);
+    expect(lf.directRequirements.size).toBe(0);
+  });
+
+  it("ignores snapshot entries that are not mappings", () => {
+    const lockfile = `lockfileVersion: '9.0'
+snapshots:
+  foo@1.0.0: invalid-string
+`;
+    const lf = parseLockfile(lockfile);
+    expect(lf.transitiveParents.size).toBe(0);
+  });
+
+  it("ignores snapshot dep maps that are not mappings", () => {
+    const lockfile = `lockfileVersion: '9.0'
+snapshots:
+  foo@1.0.0:
+    dependencies: not-a-map
+`;
+    const lf = parseLockfile(lockfile);
+    expect(lf.transitiveParents.size).toBe(0);
+  });
+
+  it("ignores snapshot dep values that are not strings", () => {
+    const lockfile = `lockfileVersion: '9.0'
+snapshots:
+  foo@1.0.0:
+    dependencies:
+      bar: {nested: object}
+`;
+    const lf = parseLockfile(lockfile);
+    expect(lf.transitiveParents.size).toBe(0);
+  });
+});

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "bun:test";
+import {
+  MalformedManifestError,
+  parsePackageJsonOverrides,
+  parseWorkspaceOverrides,
+} from "../src/manifest.ts";
+
+describe("parsePackageJsonOverrides", () => {
+  it("collects entries from pnpm.overrides", () => {
+    const content = JSON.stringify({
+      name: "demo",
+      pnpm: {
+        overrides: {
+          "@xmldom/xmldom": ">=0.9.10",
+          postcss: ">=8.5.10",
+        },
+      },
+    });
+    expect(parsePackageJsonOverrides(content)).toEqual([
+      {
+        key: "@xmldom/xmldom",
+        spec: ">=0.9.10",
+        source: "package.json:pnpm.overrides",
+      },
+      {
+        key: "postcss",
+        spec: ">=8.5.10",
+        source: "package.json:pnpm.overrides",
+      },
+    ]);
+  });
+
+  it("returns empty array when pnpm field is absent", () => {
+    expect(parsePackageJsonOverrides('{"name":"x"}')).toEqual([]);
+  });
+
+  it("returns empty array when pnpm field is not a mapping", () => {
+    expect(parsePackageJsonOverrides('{"pnpm":"oops"}')).toEqual([]);
+  });
+
+  it("returns empty array when pnpm.overrides is absent", () => {
+    expect(parsePackageJsonOverrides('{"pnpm":{}}')).toEqual([]);
+  });
+
+  it("returns empty array when pnpm.overrides is not a mapping", () => {
+    expect(parsePackageJsonOverrides('{"pnpm":{"overrides":"oops"}}')).toEqual(
+      [],
+    );
+  });
+
+  it("ignores entries whose value is not a string", () => {
+    const content = JSON.stringify({
+      pnpm: {
+        overrides: {
+          good: ">=1.0.0",
+          weird: { nested: true },
+          alsoWeird: 42,
+        },
+      },
+    });
+    expect(parsePackageJsonOverrides(content)).toEqual([
+      { key: "good", spec: ">=1.0.0", source: "package.json:pnpm.overrides" },
+    ]);
+  });
+
+  it("returns empty array when root is not an object", () => {
+    expect(parsePackageJsonOverrides("[1,2,3]")).toEqual([]);
+  });
+
+  it("throws MalformedManifestError on invalid JSON", () => {
+    expect(() => parsePackageJsonOverrides("{invalid")).toThrow(
+      MalformedManifestError,
+    );
+  });
+
+  it("collects entries from top-level overrides (npm-style)", () => {
+    const content = JSON.stringify({
+      overrides: {
+        foo: ">=1.0.0",
+      },
+    });
+    expect(parsePackageJsonOverrides(content)).toEqual([
+      { key: "foo", spec: ">=1.0.0", source: "package.json:overrides" },
+    ]);
+  });
+
+  it("collects from both pnpm.overrides and top-level overrides", () => {
+    const content = JSON.stringify({
+      pnpm: {
+        overrides: {
+          a: ">=1.0.0",
+        },
+      },
+      overrides: {
+        b: ">=2.0.0",
+      },
+    });
+    expect(parsePackageJsonOverrides(content)).toEqual([
+      { key: "a", spec: ">=1.0.0", source: "package.json:pnpm.overrides" },
+      { key: "b", spec: ">=2.0.0", source: "package.json:overrides" },
+    ]);
+  });
+
+  it("reports the same key from both locations as separate entries", () => {
+    const content = JSON.stringify({
+      pnpm: { overrides: { foo: ">=2.0.0" } },
+      overrides: { foo: ">=1.0.0" },
+    });
+    expect(parsePackageJsonOverrides(content)).toEqual([
+      { key: "foo", spec: ">=2.0.0", source: "package.json:pnpm.overrides" },
+      { key: "foo", spec: ">=1.0.0", source: "package.json:overrides" },
+    ]);
+  });
+
+  it("returns empty array when top-level overrides is not a mapping", () => {
+    expect(parsePackageJsonOverrides('{"overrides":"oops"}')).toEqual([]);
+  });
+});
+
+describe("parseWorkspaceOverrides", () => {
+  it("collects entries from workspace overrides field", () => {
+    const content = `overrides:
+  '@xmldom/xmldom': '>=0.9.10'
+  postcss: '>=8.5.10'
+`;
+    expect(parseWorkspaceOverrides(content, "pnpm-workspace.yaml")).toEqual([
+      {
+        key: "@xmldom/xmldom",
+        spec: ">=0.9.10",
+        source: "pnpm-workspace.yaml",
+      },
+      {
+        key: "postcss",
+        spec: ">=8.5.10",
+        source: "pnpm-workspace.yaml",
+      },
+    ]);
+  });
+
+  it("records aube-workspace.yaml as the source when given", () => {
+    const content = `overrides:
+  foo: '>=1.0.0'
+`;
+    expect(parseWorkspaceOverrides(content, "aube-workspace.yaml")).toEqual([
+      { key: "foo", spec: ">=1.0.0", source: "aube-workspace.yaml" },
+    ]);
+  });
+
+  it("returns empty array when overrides field is absent", () => {
+    expect(
+      parseWorkspaceOverrides(
+        "minimumReleaseAge: 1440\n",
+        "pnpm-workspace.yaml",
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns empty array when overrides field is not a mapping", () => {
+    expect(
+      parseWorkspaceOverrides("overrides: oops\n", "pnpm-workspace.yaml"),
+    ).toEqual([]);
+  });
+
+  it("ignores entries whose value is not a string", () => {
+    const content = `overrides:
+  good: '>=1.0.0'
+  weird:
+    nested: true
+`;
+    expect(parseWorkspaceOverrides(content, "pnpm-workspace.yaml")).toEqual([
+      {
+        key: "good",
+        spec: ">=1.0.0",
+        source: "pnpm-workspace.yaml",
+      },
+    ]);
+  });
+
+  it("returns empty array when root is not a mapping", () => {
+    expect(
+      parseWorkspaceOverrides("- a\n- b\n", "pnpm-workspace.yaml"),
+    ).toEqual([]);
+  });
+
+  it("returns empty array on empty content", () => {
+    expect(parseWorkspaceOverrides("", "pnpm-workspace.yaml")).toEqual([]);
+  });
+
+  it("throws MalformedManifestError on invalid YAML", () => {
+    expect(() =>
+      parseWorkspaceOverrides(": : :\n  bad:\n indent", "pnpm-workspace.yaml"),
+    ).toThrow(MalformedManifestError);
+  });
+});

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, it } from "bun:test";
+import type { Lockfile } from "../src/lockfile.ts";
+import type { Override } from "../src/manifest.ts";
+import {
+  collectNeededRegistryPackages,
+  collectPackagesForOverride,
+  evaluateOverride,
+  gatherSpecsForTarget,
+} from "../src/pipeline.ts";
+import type { PackageMetadata } from "../src/registry.ts";
+
+function makeLockfile(args: {
+  direct?: Record<string, { specifier: string; version: string }>;
+  transitive?: Record<string, Array<{ parent: string; resolved: string }>>;
+}): Lockfile {
+  const directMap = new Map<
+    string,
+    {
+      importerKey: string;
+      depType: "dependencies";
+      specifier: string;
+      resolvedVersion: string;
+    }[]
+  >();
+  for (const [name, dep] of Object.entries(args.direct ?? {})) {
+    directMap.set(name, [
+      {
+        importerKey: ".",
+        depType: "dependencies",
+        specifier: dep.specifier,
+        resolvedVersion: dep.version,
+      },
+    ]);
+  }
+  const transMap = new Map<
+    string,
+    { parentKey: string; resolvedVersion: string }[]
+  >();
+  for (const [target, parents] of Object.entries(args.transitive ?? {})) {
+    transMap.set(
+      target,
+      parents.map((p) => ({
+        parentKey: p.parent,
+        resolvedVersion: p.resolved,
+      })),
+    );
+  }
+  return {
+    version: "9.0",
+    directRequirements: directMap,
+    transitiveParents: transMap,
+  };
+}
+
+function makeMetadata(
+  name: string,
+  versions: Record<string, Record<string, string>>,
+): PackageMetadata {
+  const map = new Map<
+    string,
+    { version: string; dependencies: ReadonlyMap<string, string> }
+  >();
+  for (const [version, deps] of Object.entries(versions)) {
+    map.set(version, {
+      version,
+      dependencies: new Map(Object.entries(deps)),
+    });
+  }
+  return { name, versions: map };
+}
+
+const PKG_OVERRIDE = (key: string, spec: string): Override => ({
+  key,
+  spec,
+  source: "package.json:pnpm.overrides",
+});
+
+describe("gatherSpecsForTarget", () => {
+  it("collects specifiers from direct requirements", () => {
+    const lockfile = makeLockfile({
+      direct: { foo: { specifier: "^1.0.0", version: "1.5.0" } },
+    });
+    expect(gatherSpecsForTarget("foo", lockfile, new Map())).toEqual([
+      "^1.0.0",
+    ]);
+  });
+
+  it("collects specs from transitive parents via registry data", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        target: [
+          { parent: "parentA@1.0.0", resolved: "1.0.0" },
+          { parent: "parentB@2.0.0", resolved: "1.0.0" },
+        ],
+      },
+    });
+    const registry = new Map<string, PackageMetadata>([
+      ["parentA", makeMetadata("parentA", { "1.0.0": { target: ">=1.0.0" } })],
+      ["parentB", makeMetadata("parentB", { "2.0.0": { target: "<2.0.0" } })],
+    ]);
+    expect(gatherSpecsForTarget("target", lockfile, registry)).toEqual([
+      ">=1.0.0",
+      "<2.0.0",
+    ]);
+  });
+
+  it("combines direct and transitive specs", () => {
+    const lockfile = makeLockfile({
+      direct: { target: { specifier: "^1.0.0", version: "1.5.0" } },
+      transitive: {
+        target: [{ parent: "parentA@1.0.0", resolved: "1.5.0" }],
+      },
+    });
+    const registry = new Map<string, PackageMetadata>([
+      ["parentA", makeMetadata("parentA", { "1.0.0": { target: ">=1.2.0" } })],
+    ]);
+    expect(gatherSpecsForTarget("target", lockfile, registry)).toEqual([
+      "^1.0.0",
+      ">=1.2.0",
+    ]);
+  });
+
+  it("skips parents whose snapshot key cannot be parsed", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        target: [{ parent: "no-at-sign", resolved: "1.0.0" }],
+      },
+    });
+    expect(gatherSpecsForTarget("target", lockfile, new Map())).toEqual([]);
+  });
+
+  it("skips parents whose registry metadata is missing", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        target: [{ parent: "parentA@1.0.0", resolved: "1.0.0" }],
+      },
+    });
+    expect(gatherSpecsForTarget("target", lockfile, new Map())).toEqual([]);
+  });
+
+  it("skips parents whose version meta is missing", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        target: [{ parent: "parentA@9.9.9", resolved: "1.0.0" }],
+      },
+    });
+    const registry = new Map<string, PackageMetadata>([
+      ["parentA", makeMetadata("parentA", { "1.0.0": { target: ">=1.0.0" } })],
+    ]);
+    expect(gatherSpecsForTarget("target", lockfile, registry)).toEqual([]);
+  });
+
+  it("skips parents that don't list the target in their dependencies", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        target: [{ parent: "parentA@1.0.0", resolved: "1.0.0" }],
+      },
+    });
+    const registry = new Map<string, PackageMetadata>([
+      ["parentA", makeMetadata("parentA", { "1.0.0": { other: ">=1.0.0" } })],
+    ]);
+    expect(gatherSpecsForTarget("target", lockfile, registry)).toEqual([]);
+  });
+
+  it("returns empty array when target is not present anywhere", () => {
+    expect(
+      gatherSpecsForTarget("missing", makeLockfile({}), new Map()),
+    ).toEqual([]);
+  });
+});
+
+describe("evaluateOverride", () => {
+  it("skips entries categorized as nested-key with a reason", () => {
+    const result = evaluateOverride(
+      PKG_OVERRIDE("foo>bar", ">=1.0.0"),
+      makeLockfile({}),
+      new Map(),
+    );
+    expect(result).toEqual({ status: "skip", value: "(nested key)" });
+  });
+
+  it("skips entries with protocol-prefixed spec", () => {
+    const result = evaluateOverride(
+      PKG_OVERRIDE("foo", "catalog:default"),
+      makeLockfile({}),
+      new Map(),
+    );
+    expect(result).toEqual({ status: "skip", value: "(protocol spec)" });
+  });
+
+  it("skips entries with non-lower-bound spec", () => {
+    const result = evaluateOverride(
+      PKG_OVERRIDE("foo", "^1.0.0"),
+      makeLockfile({}),
+      new Map(),
+    );
+    expect(result).toEqual({ status: "skip", value: "(non-lower-bound)" });
+  });
+
+  it("prunes entries with no surviving constraints (unused)", () => {
+    const result = evaluateOverride(
+      PKG_OVERRIDE("foo", ">=1.0.0"),
+      makeLockfile({}),
+      new Map(),
+    );
+    expect(result).toEqual({ status: "prune", value: "(unused)" });
+  });
+
+  it("returns error when target has no registry metadata", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        foo: [{ parent: "parentA@1.0.0", resolved: "1.0.0" }],
+      },
+    });
+    const registry = new Map<string, PackageMetadata>([
+      ["parentA", makeMetadata("parentA", { "1.0.0": { foo: "^1.0.0" } })],
+    ]);
+    const result = evaluateOverride(
+      PKG_OVERRIDE("foo", ">=1.0.0"),
+      lockfile,
+      registry,
+    );
+    expect(result).toEqual({ status: "error", value: "(registry miss)" });
+  });
+
+  it("prunes when natural resolution satisfies the override floor", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        foo: [{ parent: "parentA@1.0.0", resolved: "2.5.0" }],
+      },
+    });
+    const registry = new Map<string, PackageMetadata>([
+      ["parentA", makeMetadata("parentA", { "1.0.0": { foo: ">=2.0.0" } })],
+      [
+        "foo",
+        makeMetadata("foo", {
+          "1.0.0": {},
+          "2.0.0": {},
+          "2.5.0": {},
+        }),
+      ],
+    ]);
+    const result = evaluateOverride(
+      PKG_OVERRIDE("foo", ">=2.0.0"),
+      lockfile,
+      registry,
+    );
+    expect(result).toEqual({ status: "prune", value: "2.5.0" });
+  });
+
+  it("keeps when natural resolution falls below the override floor", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        foo: [{ parent: "parentA@1.0.0", resolved: "1.5.0" }],
+      },
+    });
+    const registry = new Map<string, PackageMetadata>([
+      ["parentA", makeMetadata("parentA", { "1.0.0": { foo: "^1.0.0" } })],
+      [
+        "foo",
+        makeMetadata("foo", {
+          "1.0.0": {},
+          "1.5.0": {},
+          "2.0.0": {},
+        }),
+      ],
+    ]);
+    const result = evaluateOverride(
+      PKG_OVERRIDE("foo", ">=2.0.0"),
+      lockfile,
+      registry,
+    );
+    expect(result).toEqual({ status: "keep", value: "1.5.0" });
+  });
+});
+
+describe("collectPackagesForOverride", () => {
+  it("returns an empty list for skip-categorized overrides", () => {
+    expect(
+      collectPackagesForOverride(
+        PKG_OVERRIDE("foo", "^1.0.0"),
+        makeLockfile({}),
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns just the target when there are no transitive parents", () => {
+    expect(
+      collectPackagesForOverride(
+        PKG_OVERRIDE("foo", ">=1.0.0"),
+        makeLockfile({}),
+      ),
+    ).toEqual(["foo"]);
+  });
+
+  it("includes parent names parsed from snapshot keys", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        foo: [
+          { parent: "parentA@1.0.0", resolved: "1.0.0" },
+          { parent: "parentB@2.0.0", resolved: "1.0.0" },
+        ],
+      },
+    });
+    expect(
+      new Set(
+        collectPackagesForOverride(PKG_OVERRIDE("foo", ">=1.0.0"), lockfile),
+      ),
+    ).toEqual(new Set(["foo", "parentA", "parentB"]));
+  });
+
+  it("ignores parents whose snapshot key cannot be parsed", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        foo: [{ parent: "broken-no-at", resolved: "1.0.0" }],
+      },
+    });
+    expect(
+      collectPackagesForOverride(PKG_OVERRIDE("foo", ">=1.0.0"), lockfile),
+    ).toEqual(["foo"]);
+  });
+});
+
+describe("collectNeededRegistryPackages", () => {
+  it("includes target and parent names for each target override", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        foo: [
+          { parent: "parentA@1.0.0", resolved: "1.0.0" },
+          { parent: "parentB@2.0.0", resolved: "1.0.0" },
+        ],
+      },
+    });
+    const overrides: Override[] = [PKG_OVERRIDE("foo", ">=1.0.0")];
+    const needed = collectNeededRegistryPackages(overrides, lockfile);
+    expect(new Set(needed)).toEqual(new Set(["foo", "parentA", "parentB"]));
+  });
+
+  it("skips overrides categorized as skip", () => {
+    const overrides: Override[] = [
+      PKG_OVERRIDE("foo>bar", ">=1.0.0"),
+      PKG_OVERRIDE("baz", "^1.0.0"),
+    ];
+    expect(collectNeededRegistryPackages(overrides, makeLockfile({}))).toEqual(
+      [],
+    );
+  });
+
+  it("dedupes when the same parent appears across overrides", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        foo: [{ parent: "parentA@1.0.0", resolved: "1.0.0" }],
+        bar: [{ parent: "parentA@1.0.0", resolved: "2.0.0" }],
+      },
+    });
+    const overrides: Override[] = [
+      PKG_OVERRIDE("foo", ">=1.0.0"),
+      PKG_OVERRIDE("bar", ">=2.0.0"),
+    ];
+    const needed = collectNeededRegistryPackages(overrides, lockfile);
+    expect(new Set(needed)).toEqual(new Set(["foo", "bar", "parentA"]));
+  });
+
+  it("skips parents whose snapshot keys can't be parsed", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        foo: [{ parent: "broken-no-at", resolved: "1.0.0" }],
+      },
+    });
+    const overrides: Override[] = [PKG_OVERRIDE("foo", ">=1.0.0")];
+    expect(new Set(collectNeededRegistryPackages(overrides, lockfile))).toEqual(
+      new Set(["foo"]),
+    );
+  });
+
+  it("handles target without transitive parents", () => {
+    const overrides: Override[] = [PKG_OVERRIDE("foo", ">=1.0.0")];
+    expect(collectNeededRegistryPackages(overrides, makeLockfile({}))).toEqual([
+      "foo",
+    ]);
+  });
+});

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "bun:test";
+import {
+  MalformedRegistryResponseError,
+  parsePackageMetadata,
+} from "../src/registry.ts";
+
+describe("parsePackageMetadata", () => {
+  it("collects dependencies for each published version", () => {
+    const raw = {
+      name: "speech-rule-engine",
+      versions: {
+        "4.1.3": {
+          version: "4.1.3",
+          dependencies: {
+            "@xmldom/xmldom": "0.9.9",
+            commander: "11.1.0",
+          },
+        },
+        "4.1.4": {
+          version: "4.1.4",
+          dependencies: {
+            "@xmldom/xmldom": "0.9.10",
+            commander: "13.1.0",
+          },
+        },
+      },
+    };
+    const meta = parsePackageMetadata(raw, "speech-rule-engine");
+    expect(meta.name).toBe("speech-rule-engine");
+    expect(meta.versions.size).toBe(2);
+    const v413 = meta.versions.get("4.1.3");
+    expect(v413?.version).toBe("4.1.3");
+    expect(v413?.dependencies.get("@xmldom/xmldom")).toBe("0.9.9");
+    expect(meta.versions.get("4.1.4")?.dependencies.get("commander")).toBe(
+      "13.1.0",
+    );
+  });
+
+  it("merges peerDependencies and optionalDependencies into dependencies", () => {
+    const raw = {
+      versions: {
+        "1.0.0": {
+          dependencies: { a: ">=1.0.0" },
+          peerDependencies: { b: ">=2.0.0" },
+          optionalDependencies: { c: ">=3.0.0" },
+        },
+      },
+    };
+    const meta = parsePackageMetadata(raw, "x");
+    const v = meta.versions.get("1.0.0");
+    expect(v?.dependencies.get("a")).toBe(">=1.0.0");
+    expect(v?.dependencies.get("b")).toBe(">=2.0.0");
+    expect(v?.dependencies.get("c")).toBe(">=3.0.0");
+  });
+
+  it("dependencies takes precedence over peerDependencies on overlap", () => {
+    const raw = {
+      versions: {
+        "1.0.0": {
+          dependencies: { a: "^1.0.0" },
+          peerDependencies: { a: "^2.0.0" },
+        },
+      },
+    };
+    const meta = parsePackageMetadata(raw, "x");
+    expect(meta.versions.get("1.0.0")?.dependencies.get("a")).toBe("^1.0.0");
+  });
+
+  it("ignores non-mapping dep fields", () => {
+    const raw = {
+      versions: {
+        "1.0.0": {
+          dependencies: "oops",
+          peerDependencies: { a: ">=1.0.0" },
+        },
+      },
+    };
+    const meta = parsePackageMetadata(raw, "x");
+    expect(meta.versions.get("1.0.0")?.dependencies.get("a")).toBe(">=1.0.0");
+  });
+
+  it("ignores non-string spec entries within a dep map", () => {
+    const raw = {
+      versions: {
+        "1.0.0": {
+          dependencies: {
+            good: ">=1.0.0",
+            weird: 42,
+            alsoWeird: { nested: true },
+          },
+        },
+      },
+    };
+    const meta = parsePackageMetadata(raw, "x");
+    const deps = meta.versions.get("1.0.0")?.dependencies;
+    expect(deps?.get("good")).toBe(">=1.0.0");
+    expect(deps?.has("weird")).toBe(false);
+    expect(deps?.has("alsoWeird")).toBe(false);
+  });
+
+  it("creates an empty dep map when no dep fields are present", () => {
+    const raw = {
+      versions: {
+        "1.0.0": {},
+      },
+    };
+    const meta = parsePackageMetadata(raw, "x");
+    expect(meta.versions.get("1.0.0")?.dependencies.size).toBe(0);
+  });
+
+  it("ignores version entries that are not mappings", () => {
+    const raw = {
+      versions: {
+        "1.0.0": "should-be-object",
+        "2.0.0": {},
+      },
+    };
+    const meta = parsePackageMetadata(raw, "x");
+    expect(meta.versions.has("1.0.0")).toBe(false);
+    expect(meta.versions.has("2.0.0")).toBe(true);
+  });
+
+  it("throws when root is not an object", () => {
+    expect(() => parsePackageMetadata("not-an-object", "x")).toThrow(
+      MalformedRegistryResponseError,
+    );
+  });
+
+  it("throws when versions field is missing", () => {
+    expect(() => parsePackageMetadata({ name: "x" }, "x")).toThrow(
+      MalformedRegistryResponseError,
+    );
+  });
+
+  it("throws when versions field is not a mapping", () => {
+    expect(() => parsePackageMetadata({ versions: "oops" }, "x")).toThrow(
+      MalformedRegistryResponseError,
+    );
+  });
+});

--- a/tests/resolve.test.ts
+++ b/tests/resolve.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import { computeNaturalResolution } from "../src/resolve.ts";
+
+describe("computeNaturalResolution", () => {
+  it("returns the max version satisfying all parent specs", () => {
+    expect(
+      computeNaturalResolution(
+        [">=1.0.0", "<3.0.0"],
+        ["0.5.0", "1.5.0", "2.0.0", "3.5.0"],
+      ),
+    ).toBe("2.0.0");
+  });
+
+  it("intersects caret and tilde ranges correctly", () => {
+    expect(
+      computeNaturalResolution(
+        ["^1.2.3", "~1.5.0"],
+        ["1.4.0", "1.5.5", "1.5.9", "1.6.0", "2.0.0"],
+      ),
+    ).toBe("1.5.9");
+  });
+
+  it("returns null when no parent specs are given", () => {
+    expect(computeNaturalResolution([], ["1.0.0", "2.0.0"])).toBeNull();
+  });
+
+  it("returns null when no candidate versions are given", () => {
+    expect(computeNaturalResolution([">=1.0.0"], [])).toBeNull();
+  });
+
+  it("returns null when no candidate satisfies the intersection", () => {
+    expect(
+      computeNaturalResolution([">=10.0.0"], ["1.0.0", "2.0.0"]),
+    ).toBeNull();
+  });
+
+  it("handles a single spec correctly", () => {
+    expect(
+      computeNaturalResolution([">=1.0.0"], ["0.5.0", "1.0.0", "1.5.0"]),
+    ).toBe("1.5.0");
+  });
+
+  it("ignores pre-release versions when ranges are stable", () => {
+    expect(
+      computeNaturalResolution([">=1.0.0"], ["1.0.0", "1.1.0-beta.1", "1.0.5"]),
+    ).toBe("1.0.5");
+  });
+
+  it("handles invalid candidate versions by filtering them out", () => {
+    // satisfies() returns false on invalid versions instead of throwing.
+    expect(
+      computeNaturalResolution(
+        [">=1.0.0"],
+        ["not-a-version", "1.5.0", "2.0.0"],
+      ),
+    ).toBe("2.0.0");
+  });
+
+  it("handles invalid parent specs by filtering all candidates out", () => {
+    // satisfies() returns false on invalid specs, so nothing matches.
+    expect(
+      computeNaturalResolution(["not-a-spec"], ["1.0.0", "2.0.0"]),
+    ).toBeNull();
+  });
+});

--- a/tests/rewrite.test.ts
+++ b/tests/rewrite.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "bun:test";
+import {
+  removeFromPackageJson,
+  removeFromWorkspaceYaml,
+} from "../src/rewrite.ts";
+
+function pnpm(keys: readonly string[]) {
+  return { fromPnpmOverrides: keys, fromTopLevelOverrides: [] as string[] };
+}
+
+function topLevel(keys: readonly string[]) {
+  return { fromPnpmOverrides: [] as string[], fromTopLevelOverrides: keys };
+}
+
+describe("removeFromPackageJson", () => {
+  it("removes the given keys from pnpm.overrides", () => {
+    const before = `{
+  "name": "demo",
+  "pnpm": {
+    "overrides": {
+      "@xmldom/xmldom": ">=0.9.10",
+      "postcss": ">=8.5.10",
+      "keep-me": "1.0.0"
+    }
+  }
+}
+`;
+    const after = removeFromPackageJson(
+      before,
+      pnpm(["@xmldom/xmldom", "postcss"]),
+    );
+    const parsed = JSON.parse(after) as Record<string, unknown>;
+    const pnpmField = parsed.pnpm as Record<string, unknown>;
+    const overrides = pnpmField.overrides as Record<string, unknown>;
+    expect(Object.keys(overrides)).toEqual(["keep-me"]);
+    expect(overrides["keep-me"]).toBe("1.0.0");
+  });
+
+  it("removes the given keys from top-level overrides", () => {
+    const before = `{
+  "name": "demo",
+  "overrides": {
+    "foo": ">=1.0.0",
+    "bar": ">=2.0.0"
+  }
+}
+`;
+    const after = removeFromPackageJson(before, topLevel(["foo"]));
+    const parsed = JSON.parse(after) as Record<string, unknown>;
+    const overrides = parsed.overrides as Record<string, unknown>;
+    expect(Object.keys(overrides)).toEqual(["bar"]);
+  });
+
+  it("removes from both containers in a single call", () => {
+    const before = `{
+  "pnpm": { "overrides": { "a": "1", "b": "2" } },
+  "overrides": { "c": "3", "d": "4" }
+}
+`;
+    const after = removeFromPackageJson(before, {
+      fromPnpmOverrides: ["a"],
+      fromTopLevelOverrides: ["d"],
+    });
+    const parsed = JSON.parse(after) as Record<string, unknown>;
+    const pnpmField = parsed.pnpm as Record<string, unknown>;
+    expect(Object.keys(pnpmField.overrides as Record<string, unknown>)).toEqual(
+      ["b"],
+    );
+    expect(Object.keys(parsed.overrides as Record<string, unknown>)).toEqual([
+      "c",
+    ]);
+  });
+
+  it("preserves trailing newline when present in input", () => {
+    const before = `{"pnpm":{"overrides":{"foo":">=1.0.0"}}}\n`;
+    const after = removeFromPackageJson(before, pnpm(["foo"]));
+    expect(after.endsWith("\n")).toBe(true);
+  });
+
+  it("omits trailing newline when input lacks one", () => {
+    const before = `{"pnpm":{"overrides":{"foo":">=1.0.0"}}}`;
+    const after = removeFromPackageJson(before, pnpm(["foo"]));
+    expect(after.endsWith("\n")).toBe(false);
+  });
+
+  it("preserves 4-space indent when input uses it", () => {
+    const before = `{
+    "pnpm": {
+        "overrides": {
+            "foo": ">=1.0.0",
+            "bar": ">=2.0.0"
+        }
+    }
+}
+`;
+    const after = removeFromPackageJson(before, pnpm(["foo"]));
+    expect(after).toContain('    "pnpm"');
+    expect(after).toContain('        "overrides"');
+  });
+
+  it("preserves tab indent when input uses tabs", () => {
+    const before =
+      '{\n\t"pnpm": {\n\t\t"overrides": {\n\t\t\t"foo": ">=1.0.0"\n\t\t}\n\t}\n}\n';
+    const after = removeFromPackageJson(before, pnpm(["foo"]));
+    expect(after).toContain("\t");
+  });
+
+  it("returns content unchanged when both removal lists are empty", () => {
+    const before = `{"pnpm":{"overrides":{"foo":">=1.0.0"}}}`;
+    expect(
+      removeFromPackageJson(before, {
+        fromPnpmOverrides: [],
+        fromTopLevelOverrides: [],
+      }),
+    ).toBe(before);
+  });
+
+  it("returns content unchanged when pnpm field is absent", () => {
+    const before = `{"name":"x"}`;
+    expect(removeFromPackageJson(before, pnpm(["foo"]))).toBe(before);
+  });
+
+  it("returns content unchanged when pnpm field is not a mapping", () => {
+    const before = `{"pnpm":"oops"}`;
+    expect(removeFromPackageJson(before, pnpm(["foo"]))).toBe(before);
+  });
+
+  it("returns content unchanged when pnpm.overrides is absent", () => {
+    const before = `{"pnpm":{}}`;
+    expect(removeFromPackageJson(before, pnpm(["foo"]))).toBe(before);
+  });
+
+  it("returns content unchanged when pnpm.overrides is not a mapping", () => {
+    const before = `{"pnpm":{"overrides":"oops"}}`;
+    expect(removeFromPackageJson(before, pnpm(["foo"]))).toBe(before);
+  });
+
+  it("returns content unchanged when top-level overrides is absent", () => {
+    const before = `{"name":"x"}`;
+    expect(removeFromPackageJson(before, topLevel(["foo"]))).toBe(before);
+  });
+
+  it("returns content unchanged when top-level overrides is not a mapping", () => {
+    const before = `{"overrides":"oops"}`;
+    expect(removeFromPackageJson(before, topLevel(["foo"]))).toBe(before);
+  });
+
+  it("returns content unchanged when root is not an object", () => {
+    const before = `[1,2,3]`;
+    expect(removeFromPackageJson(before, pnpm(["foo"]))).toBe(before);
+  });
+
+  it("leaves remaining override keys untouched and stable in order", () => {
+    const before = `{
+  "pnpm": {
+    "overrides": {
+      "a": "1",
+      "b": "2",
+      "c": "3"
+    }
+  }
+}
+`;
+    const after = removeFromPackageJson(before, pnpm(["b"]));
+    expect(after).toContain('"a": "1"');
+    expect(after).toContain('"c": "3"');
+    expect(after).not.toContain('"b"');
+    expect(after.indexOf('"a"')).toBeLessThan(after.indexOf('"c"'));
+  });
+});
+
+describe("removeFromWorkspaceYaml", () => {
+  it("removes the given keys from overrides field", () => {
+    const before = `overrides:
+  '@xmldom/xmldom': '>=0.9.10'
+  postcss: '>=8.5.10'
+  keep-me: '1.0.0'
+`;
+    const after = removeFromWorkspaceYaml(before, [
+      "@xmldom/xmldom",
+      "postcss",
+    ]);
+    expect(after).toContain("keep-me");
+    expect(after).not.toContain("@xmldom/xmldom");
+    expect(after).not.toContain("postcss");
+  });
+
+  it("preserves comments and surrounding fields", () => {
+    const before = `# top comment
+minimumReleaseAge: 1440
+
+overrides:
+  foo: '>=1.0.0'
+  bar: '>=2.0.0'
+
+# trailing comment
+`;
+    const after = removeFromWorkspaceYaml(before, ["foo"]);
+    expect(after).toContain("# top comment");
+    expect(after).toContain("minimumReleaseAge: 1440");
+    expect(after).toContain("# trailing comment");
+    expect(after).toContain("bar:");
+    expect(after).not.toMatch(/^\s+foo:/m);
+  });
+
+  it("returns content unchanged when keys is empty", () => {
+    const before = `overrides:\n  foo: '>=1.0.0'\n`;
+    expect(removeFromWorkspaceYaml(before, [])).toBe(before);
+  });
+
+  it("returns content (re-emitted) when overrides field is absent", () => {
+    const before = "minimumReleaseAge: 1440\n";
+    const after = removeFromWorkspaceYaml(before, ["foo"]);
+    expect(after).toContain("minimumReleaseAge: 1440");
+  });
+});

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { decideRun } from "../src/run.ts";
+
+describe("decideRun", () => {
+  it("returns sync version output for -V", () => {
+    const result = decideRun(["-V"], "1.2.3");
+    expect(result).toEqual({
+      kind: "sync",
+      exitCode: 0,
+      stdout: "pnpm-override-prune 1.2.3\n",
+      stderr: "",
+    });
+  });
+
+  it("returns sync version output for --version", () => {
+    const result = decideRun(["--version"], "1.2.3");
+    expect(result.kind).toBe("sync");
+    if (result.kind === "sync") {
+      expect(result.stdout).toBe("pnpm-override-prune 1.2.3\n");
+    }
+  });
+
+  it("returns sync help output for -h", () => {
+    const result = decideRun(["-h"], "1.2.3");
+    expect(result.kind).toBe("sync");
+    if (result.kind === "sync") {
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Usage: pnpm-override-prune");
+    }
+  });
+
+  it("returns sync help output for --help", () => {
+    const result = decideRun(["--help"], "1.2.3");
+    expect(result.kind).toBe("sync");
+  });
+
+  it("returns sync error output with exit code 2 on bad args", () => {
+    const result = decideRun(["a", "b"], "1.2.3");
+    expect(result.kind).toBe("sync");
+    if (result.kind === "sync") {
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toMatch(/^error: /);
+      expect(result.stdout).toBe("");
+    }
+  });
+
+  it("returns audit request with default path when given no args", () => {
+    expect(decideRun([], "1.2.3")).toEqual({
+      kind: "audit",
+      path: "./package.json",
+      fix: false,
+    });
+  });
+
+  it("returns audit request with path and fix when both are given", () => {
+    expect(decideRun(["custom/package.json", "--fix"], "1.2.3")).toEqual({
+      kind: "audit",
+      path: "custom/package.json",
+      fix: true,
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun", "node"],
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src", "tests"]
+}

--- a/validate.sh
+++ b/validate.sh
@@ -6,10 +6,18 @@ eval "$(mise activate bash)"
 mise fmt
 mise install
 
+# TypeScript
+aube install --frozen-lockfile
+aube licenses
+aube audit --fix --ignore-unfixable
+aube exec biome migrate --write
+aube run check:write
+aube run typecheck
+aube run test
+aube run build
+
 # Run shared lint tasks
 mise run gha-lint
-
-# Add repo-specific lint here
 
 # Check for uncommitted changes
 git diff --exit-code


### PR DESCRIPTION
## Summary

CLI tool that detects prunable `pnpm.overrides` entries by gathering parent specs from the lockfile and the npm registry, then comparing the natural-resolution max-satisfying version against each override's lower bound.

- Reads `pnpm.overrides` and top-level `overrides` from `package.json`, plus top-level `overrides` from `pnpm-workspace.yaml` / `aube-workspace.yaml`
- Supports `pnpm-lock.yaml` and `aube-lock.yaml` at `lockfileVersion: '9.0'`
- Verdicts: `[PRUNE]` / `[KEEP]` / `[SKIP]` / `[ERROR]`; `--fix` removes `[PRUNE]` entries in place (preserves JSON indent and YAML comments)
- Streaming output: section header prints immediately after parse, entry verdicts stream in input order while registry fetches happen in parallel
- TypeScript + bun + biome toolchain, mise pinning, tag-driven npm publish workflow on `v*.*.*` tags
- `engines.node: ">=20"`; compatibility matrix runs against Node 20 / 22 / 24
- Pure modules at 100% line/func coverage; I/O layer integration-tested via local smoke runs (against `~/marp-agent-mcp` and synthetic dual-source fixtures)

See README for usage, scope, and known limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)