### PR TITLE
chore: switch publish workflow to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,8 +28,4 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           npm pkg set version="$VERSION"
       - run: aube run build
-      - run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          npm publish --provenance --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

Trusted Publisher is now registered on npm for this package (repo `iwamot/pnpm-override-prune`, workflow `publish.yml`, environment `production`). With that in place the npm CLI can authenticate via the OIDC token granted by `id-token: write`, so the `NPM_TOKEN`-based `.npmrc` setup is redundant.

- Drops `.npmrc` auth-token write and the `NPM_TOKEN` env var
- Node 24.x ships npm 11.12.1, which already satisfies the `>= 11.5.1` requirement for OIDC trusted publishing — no extra `npm install -g` step needed
- Inline (non-reusable) workflow is intentional: `job_workflow_ref` must match the caller's `publish.yml` path for trusted publishing to accept the OIDC claim. The same constraint applied to `uv-override-prune` on PyPI.

## Follow-up after this merges and a v0.0.x publish succeeds via OIDC

- Switch the npm package's "Require additional auth method" setting from "or token w/ bypass 2FA" to **"and disallow tokens (recommended)"**
- Delete the `NPM_TOKEN` secret from the GitHub repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)