### PR TITLE
chore: dogfood pnpm-override-prune in validate.sh

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,10 @@ bun = "1.3.13"
 node = "24.15.0"
 "npm:@endevco/aube" = "1.2.0"
 
+[tools."npm:pnpm-override-prune"]
+version = "0.0.2"
+install_before = "0d"
+
 [task_config]
 includes = [
   "git::https://github.com/iwamot/mise-tasks.git//.mise/tasks?ref=v1.1.0",

--- a/validate.sh
+++ b/validate.sh
@@ -10,6 +10,7 @@ mise install
 aube install --frozen-lockfile
 aube licenses
 aube audit --fix --ignore-unfixable
+pnpm-override-prune --fix
 aube exec biome migrate --write
 aube run check:write
 aube run typecheck


### PR DESCRIPTION
## Summary

- Declare `npm:pnpm-override-prune` in `mise.toml` (pinned to 0.0.2, `install_before = "0d"`).
- Add `pnpm-override-prune --fix` to `validate.sh` right after `aube audit`, mirroring the pattern used in iwamot/uv-override-prune#21 and iwamot/collmbo#170.
- mise puts the npm-installed binary on PATH the same way it does for `npm:@endevco/aube`, so no `aube exec` / `npx` wrapping is needed. `compatibility.sh` continues to E2E the local build via `npm pack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)