### PR TITLE
docs: add npm version and node engine badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Validate](https://github.com/iwamot/pnpm-override-prune/actions/workflows/validate.yml/badge.svg)](https://github.com/iwamot/pnpm-override-prune/actions/workflows/validate.yml)
 [![codecov](https://codecov.io/gh/iwamot/pnpm-override-prune/graph/badge.svg)](https://codecov.io/gh/iwamot/pnpm-override-prune)
+[![npm](https://img.shields.io/npm/v/pnpm-override-prune.svg)](https://www.npmjs.com/package/pnpm-override-prune)
+[![Node](https://img.shields.io/node/v/pnpm-override-prune.svg)](https://www.npmjs.com/package/pnpm-override-prune)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Detect prunable override entries in pnpm / [aube](https://github.com/endevco/aube) projects.


### PR DESCRIPTION
## Summary
- Add npm latest-version badge (`img.shields.io/npm/v`) and Node engine badge (`img.shields.io/node/v`) to the README
- Mirrors the PyPI / Python badges in `uv-override-prune`

🤖 Generated with [Claude Code](https://claude.com/claude-code)