### PR TITLE
chore: switch publish.yml to iwamot/actions/npm-publish composite action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,16 +16,4 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        with:
-          experimental: true
-          cache: false
-      - run: aube install --frozen-lockfile
-      - run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          npm pkg set version="$VERSION"
-      - run: aube run build
-      - run: npm publish --provenance --access public
+      - uses: iwamot/actions/npm-publish@792bb6f7b66b5d046aa285d39303a0aa7b10f822 # v0.5.0


### PR DESCRIPTION
## Summary

- Replace inline `publish.yml` steps with a single `iwamot/actions/npm-publish@v0.5.0` step.
- Drop `experimental: true` (no experimental backends in `mise.toml`); the new action sets `cache: false` on `mise-action`, matching the previous behavior and the `uv-publish` precedent (one-shot publish, no cache benefit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)