### PR TITLE
feat: improve override evaluation accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,12 @@ Once they do, the entry is no longer doing anything — but it's easy to forget 
 
 ## How it works
 
-For each override target, the tool gathers the specs that constrain it — direct importer specs from the lockfile plus parent-package metadata from `https://registry.npmjs.org` — and computes the highest published version satisfying their intersection. If that natural resolution already meets the override's lower bound, the entry is `[PRUNE]`.
+For each override target, the tool gathers the specs that constrain it without the override applied:
+
+- direct importer specs read from each workspace `package.json` (the lockfile's importer specifiers are skipped because pnpm rewrites them to the override value)
+- parent-package metadata fetched from `https://registry.npmjs.org` for transitive parents
+
+For each spec it computes the highest published version that spec would resolve to on its own. The reported version is the **lowest** of those — the worst case some consumer would land on if the override were removed. If that version already meets the override's lower bound, the entry is `[PRUNE]`; otherwise `[KEEP]`.
 
 ## Scope
 
@@ -67,6 +72,7 @@ For each override target, the tool gathers the specs that constrain it — direc
 
 - Skips values using non-semver protocols (`catalog:`, `workspace:`, `file:`, `link:`, `portal:`, `npm:`, `github:`, `git`-prefixed, `http:` / `https:`).
 - Skips nested-key overrides like `"parent>child": "1.2.3"`. Only flat `name &rarr; spec` mappings are evaluated.
+- Skips versioned keys like `"ajv@^8.0.0": ">=8.18.0"`. Such entries combine a selector and a replacement; safely transforming them is not expressible in pnpm syntax, so the verdict is left for human review.
 - Public npm registry only. Private registries and `.npmrc` scoped registry configuration are not consulted.
 - Parents that aren't on the public registry — e.g. workspace-internal packages resolved as transitive parents — are silently dropped from the constraint set. The natural resolution may then appear less constrained than it actually is.
 

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -40,11 +40,22 @@ export function isNestedKey(key: string): boolean {
   return key.includes(">");
 }
 
+export function isVersionedKey(key: string): boolean {
+  // Detect keys carrying a version constraint, e.g. "ajv@^8.0.0" or
+  // "@scope/pkg@^1.0.0". For "@scope/pkg" the only "@" is the scope marker
+  // at index 0, so we require the separator to appear after position 0.
+  return key.lastIndexOf("@") > 0;
+}
+
 export function hasProtocolPrefix(spec: string): boolean {
   return PROTOCOL_PREFIXES.some((prefix) => spec.startsWith(prefix));
 }
 
-export type SkipReason = "nested-key" | "protocol-spec" | "non-lower-bound";
+export type SkipReason =
+  | "nested-key"
+  | "versioned-key"
+  | "protocol-spec"
+  | "non-lower-bound";
 
 export type Categorization =
   | { readonly kind: "target"; readonly spec: string }
@@ -53,6 +64,9 @@ export type Categorization =
 export function categorize(key: string, spec: string): Categorization {
   if (isNestedKey(key)) {
     return { kind: "skip", reason: "nested-key" };
+  }
+  if (isVersionedKey(key)) {
+    return { kind: "skip", reason: "versioned-key" };
   }
   if (hasProtocolPrefix(spec)) {
     return { kind: "skip", reason: "protocol-spec" };

--- a/src/core.ts
+++ b/src/core.ts
@@ -10,9 +10,11 @@ import {
 } from "./format.ts";
 import { type Lockfile, parseLockfile } from "./lockfile.ts";
 import {
+  buildWorkspaceDirectDeps,
   type Override,
   parsePackageJsonOverrides,
   parseWorkspaceOverrides,
+  type WorkspaceDirectDeps,
   type WorkspaceFilename,
 } from "./manifest.ts";
 import {
@@ -59,6 +61,23 @@ async function findFirstExisting(
     }
   }
   return null;
+}
+
+async function readWorkspaceDirectDeps(
+  lockfileDir: string,
+  importerPaths: readonly string[],
+): Promise<WorkspaceDirectDeps> {
+  const importerContents = new Map<string, string>();
+  await Promise.all(
+    importerPaths.map(async (importerKey) => {
+      const path = join(lockfileDir, importerKey, "package.json");
+      const content = await readFileIfExists(path);
+      if (content !== null) {
+        importerContents.set(importerKey, content);
+      }
+    }),
+  );
+  return buildWorkspaceDirectDeps(importerContents);
 }
 
 function workspaceFilenameFromPath(path: string): WorkspaceFilename {
@@ -138,6 +157,7 @@ export async function runAudit(
   }
   let allOverrides: readonly Override[];
   let lockfile: Lockfile;
+  let workspaceDirectDeps: WorkspaceDirectDeps;
   try {
     const fromPackage = parsePackageJsonOverrides(packageJsonContent);
     const fromWorkspace =
@@ -149,6 +169,10 @@ export async function runAudit(
           );
     allOverrides = [...fromPackage, ...fromWorkspace];
     lockfile = parseLockfile(lockResult.content);
+    workspaceDirectDeps = await readWorkspaceDirectDeps(
+      dir,
+      lockfile.importerPaths,
+    );
   } catch (e) {
     emitError(e instanceof Error ? e.message : "parse error");
     return 2;
@@ -194,7 +218,12 @@ export async function runAudit(
           dataMap.set(name, meta);
         }
       }
-      const result = evaluateOverride(override, lockfile, dataMap);
+      const result = evaluateOverride(
+        override,
+        lockfile,
+        workspaceDirectDeps,
+        dataMap,
+      );
       const entry: AuditEntry = { override, result };
       collectedEntries.push(entry);
       if (result.status === "prune") {

--- a/src/lockfile.ts
+++ b/src/lockfile.ts
@@ -2,15 +2,6 @@ import { parse as parseYaml } from "yaml";
 
 export const SUPPORTED_LOCKFILE_VERSION = "9.0";
 
-const DIRECT_DEP_FIELDS = [
-  "dependencies",
-  "devDependencies",
-  "peerDependencies",
-  "optionalDependencies",
-] as const;
-
-export type DirectDepType = (typeof DIRECT_DEP_FIELDS)[number];
-
 export class UnsupportedLockfileVersionError extends Error {
   override readonly name = "UnsupportedLockfileVersionError";
   readonly found: string | null;
@@ -31,13 +22,6 @@ export class MalformedLockfileError extends Error {
   }
 }
 
-export interface DirectRequirement {
-  readonly importerKey: string;
-  readonly depType: DirectDepType;
-  readonly specifier: string;
-  readonly resolvedVersion: string;
-}
-
 export interface ParentRequirement {
   readonly parentKey: string;
   readonly resolvedVersion: string;
@@ -45,10 +29,7 @@ export interface ParentRequirement {
 
 export interface Lockfile {
   readonly version: string;
-  readonly directRequirements: ReadonlyMap<
-    string,
-    readonly DirectRequirement[]
-  >;
+  readonly importerPaths: readonly string[];
   readonly transitiveParents: ReadonlyMap<string, readonly ParentRequirement[]>;
 }
 
@@ -94,42 +75,12 @@ function appendToMultiMap<K, V>(map: Map<K, V[]>, key: K, value: V): void {
   }
 }
 
-function extractDirectRequirements(
-  raw: Record<string, unknown>,
-): ReadonlyMap<string, readonly DirectRequirement[]> {
-  const map = new Map<string, DirectRequirement[]>();
+function extractImporterPaths(raw: Record<string, unknown>): readonly string[] {
   const importers = raw.importers;
   if (!isObject(importers)) {
-    return map;
+    return [];
   }
-  for (const [importerKey, importerValue] of Object.entries(importers)) {
-    if (!isObject(importerValue)) {
-      continue;
-    }
-    for (const depType of DIRECT_DEP_FIELDS) {
-      const deps = importerValue[depType];
-      if (!isObject(deps)) {
-        continue;
-      }
-      for (const [pkgName, depValue] of Object.entries(deps)) {
-        if (!isObject(depValue)) {
-          continue;
-        }
-        const specifier = depValue.specifier;
-        const version = depValue.version;
-        if (typeof specifier !== "string" || typeof version !== "string") {
-          continue;
-        }
-        appendToMultiMap(map, pkgName, {
-          importerKey,
-          depType,
-          specifier,
-          resolvedVersion: parseResolvedVersion(version),
-        });
-      }
-    }
-  }
-  return map;
+  return Object.keys(importers);
 }
 
 function extractTransitiveParents(
@@ -182,7 +133,7 @@ export function parseLockfile(content: string): Lockfile {
   }
   return {
     version,
-    directRequirements: extractDirectRequirements(parsed),
+    importerPaths: extractImporterPaths(parsed),
     transitiveParents: extractTransitiveParents(parsed),
   };
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -12,6 +12,27 @@ export interface Override {
   readonly source: OverrideSource;
 }
 
+export type DirectDepType =
+  | "dependencies"
+  | "devDependencies"
+  | "peerDependencies"
+  | "optionalDependencies";
+
+const DIRECT_DEP_FIELDS: readonly DirectDepType[] = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+];
+
+export interface DirectDep {
+  readonly importerKey: string;
+  readonly depType: DirectDepType;
+  readonly spec: string;
+}
+
+export type WorkspaceDirectDeps = ReadonlyMap<string, readonly DirectDep[]>;
+
 export class MalformedManifestError extends Error {
   override readonly name = "MalformedManifestError";
   constructor(message: string) {
@@ -70,6 +91,44 @@ export function parsePackageJsonOverrides(
     );
   }
   return result;
+}
+
+export function buildWorkspaceDirectDeps(
+  importerContents: ReadonlyMap<string, string>,
+): WorkspaceDirectDeps {
+  const map = new Map<string, DirectDep[]>();
+  for (const [importerKey, content] of importerContents) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch (e) {
+      throw new MalformedManifestError(
+        e instanceof Error ? e.message : "json parse error",
+      );
+    }
+    if (!isObject(parsed)) {
+      continue;
+    }
+    for (const depType of DIRECT_DEP_FIELDS) {
+      const deps = parsed[depType];
+      if (!isObject(deps)) {
+        continue;
+      }
+      for (const [name, spec] of Object.entries(deps)) {
+        if (typeof spec !== "string") {
+          continue;
+        }
+        const entry: DirectDep = { importerKey, depType, spec };
+        const existing = map.get(name);
+        if (existing === undefined) {
+          map.set(name, [entry]);
+        } else {
+          existing.push(entry);
+        }
+      }
+    }
+  }
+  return map;
 }
 
 export function parseWorkspaceOverrides(

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,11 +1,12 @@
 import {
   categorize,
   classify,
+  hasProtocolPrefix,
   type Result,
   type SkipReason,
 } from "./analyze.ts";
 import { type Lockfile, parseSnapshotKey } from "./lockfile.ts";
-import type { Override } from "./manifest.ts";
+import type { Override, WorkspaceDirectDeps } from "./manifest.ts";
 import type { PackageMetadata } from "./registry.ts";
 import { computeNaturalResolution } from "./resolve.ts";
 
@@ -18,6 +19,8 @@ function skipReasonToValue(reason: SkipReason): string {
   switch (reason) {
     case "nested-key":
       return "(nested key)";
+    case "versioned-key":
+      return "(versioned key)";
     case "protocol-spec":
       return "(protocol spec)";
     case "non-lower-bound":
@@ -28,13 +31,17 @@ function skipReasonToValue(reason: SkipReason): string {
 export function gatherSpecsForTarget(
   target: string,
   lockfile: Lockfile,
+  workspaceDirectDeps: WorkspaceDirectDeps,
   registryData: ReadonlyMap<string, PackageMetadata>,
 ): readonly string[] {
   const specs: string[] = [];
-  const direct = lockfile.directRequirements.get(target);
+  const direct = workspaceDirectDeps.get(target);
   if (direct !== undefined) {
-    for (const req of direct) {
-      specs.push(req.specifier);
+    for (const dep of direct) {
+      if (hasProtocolPrefix(dep.spec)) {
+        continue;
+      }
+      specs.push(dep.spec);
     }
   }
   const parents = lockfile.transitiveParents.get(target);
@@ -65,13 +72,19 @@ export function gatherSpecsForTarget(
 export function evaluateOverride(
   override: Override,
   lockfile: Lockfile,
+  workspaceDirectDeps: WorkspaceDirectDeps,
   registryData: ReadonlyMap<string, PackageMetadata>,
 ): Result {
   const cat = categorize(override.key, override.spec);
   if (cat.kind === "skip") {
     return { status: "skip", value: skipReasonToValue(cat.reason) };
   }
-  const specs = gatherSpecsForTarget(override.key, lockfile, registryData);
+  const specs = gatherSpecsForTarget(
+    override.key,
+    lockfile,
+    workspaceDirectDeps,
+    registryData,
+  );
   if (specs.length === 0) {
     return { status: "prune", value: "(unused)" };
   }

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,12 +1,16 @@
-import { maxSatisfying, satisfies } from "semver";
+import { compare, maxSatisfying } from "semver";
 
 /**
- * Given parent dependency specs and a list of candidate published versions,
- * compute the highest version that satisfies all parent specs simultaneously.
+ * For each importer/parent spec, compute the highest published version that
+ * spec would resolve to on its own. Return the lowest of those — i.e. the
+ * worst-case version some consumer would land on if the override were removed.
  *
- * Returns null when there are no parent specs, no candidates, or no version
- * satisfies the intersection. Pre-releases are ignored unless they fall inside
- * a parent spec that explicitly opts them in.
+ * pnpm doesn't always hoist to a single version; when specs disagree, multiple
+ * versions get installed. Reporting the lowest means PRUNE only when *every*
+ * consumer would land at or above the override floor.
+ *
+ * Returns null when there are no parent specs or no candidates. Specs that no
+ * candidate satisfies are skipped (treated as inert constraints).
  */
 export function computeNaturalResolution(
   parentSpecs: readonly string[],
@@ -15,10 +19,17 @@ export function computeNaturalResolution(
   if (parentSpecs.length === 0 || candidateVersions.length === 0) {
     return null;
   }
-  const filtered = candidateVersions.filter((version) =>
-    parentSpecs.every((spec) =>
-      satisfies(version, spec, { includePrerelease: false }),
-    ),
-  );
-  return maxSatisfying(filtered, ">=0.0.0", { includePrerelease: false });
+  let lowest: string | null = null;
+  for (const spec of parentSpecs) {
+    const max = maxSatisfying(candidateVersions, spec, {
+      includePrerelease: false,
+    });
+    if (max === null) {
+      continue;
+    }
+    if (lowest === null || compare(max, lowest) < 0) {
+      lowest = max;
+    }
+  }
+  return lowest;
 }

--- a/tests/analyze.test.ts
+++ b/tests/analyze.test.ts
@@ -5,6 +5,7 @@ import {
   hasProtocolPrefix,
   isNestedKey,
   isPureLowerBound,
+  isVersionedKey,
 } from "../src/analyze.ts";
 
 describe("isPureLowerBound", () => {
@@ -62,6 +63,32 @@ describe("isNestedKey", () => {
 
   it("treats scoped flat name as not nested", () => {
     expect(isNestedKey("@scope/foo")).toBe(false);
+  });
+});
+
+describe("isVersionedKey", () => {
+  it("treats plain name as not versioned", () => {
+    expect(isVersionedKey("foo")).toBe(false);
+  });
+
+  it("treats scoped name as not versioned", () => {
+    expect(isVersionedKey("@scope/foo")).toBe(false);
+  });
+
+  it("recognizes name with caret range", () => {
+    expect(isVersionedKey("ajv@^8.0.0")).toBe(true);
+  });
+
+  it("recognizes scoped name with caret range", () => {
+    expect(isVersionedKey("@azure/core-rest-pipeline@^1.0.0")).toBe(true);
+  });
+
+  it("recognizes name with exact pin", () => {
+    expect(isVersionedKey("foo@1.0.0")).toBe(true);
+  });
+
+  it("treats empty string as not versioned", () => {
+    expect(isVersionedKey("")).toBe(false);
   });
 });
 
@@ -132,6 +159,20 @@ describe("categorize", () => {
     });
   });
 
+  it("skips versioned keys", () => {
+    expect(categorize("ajv@^8.0.0", ">=8.18.0")).toEqual({
+      kind: "skip",
+      reason: "versioned-key",
+    });
+  });
+
+  it("skips scoped versioned keys", () => {
+    expect(categorize("@azure/core-rest-pipeline@^1.0.0", ">=1.14.0")).toEqual({
+      kind: "skip",
+      reason: "versioned-key",
+    });
+  });
+
   it("skips protocol specs", () => {
     expect(categorize("foo", "catalog:default")).toEqual({
       kind: "skip",
@@ -160,9 +201,15 @@ describe("categorize", () => {
     });
   });
 
+  it("nested-key takes precedence over versioned-key", () => {
+    // 'foo>bar@1.0.0' has '>' so it's nested first.
+    expect(categorize("foo>bar@1.0.0", ">=1.0.0")).toEqual({
+      kind: "skip",
+      reason: "nested-key",
+    });
+  });
+
   it("protocol takes precedence over non-lower-bound check", () => {
-    // "catalog:default" would also fail isPureLowerBound, but the protocol
-    // reason is more informative.
     expect(categorize("foo", "catalog:default")).toEqual({
       kind: "skip",
       reason: "protocol-spec",

--- a/tests/lockfile.test.ts
+++ b/tests/lockfile.test.ts
@@ -113,26 +113,28 @@ describe("parseLockfile", () => {
     expect(lf.version).toBe("9.0");
   });
 
-  it("collects direct requirements with specifier and resolved version", () => {
+  it("collects importer paths from the importers section", () => {
     const lf = parseLockfile(VALID_LOCKFILE);
-    const semver = lf.directRequirements.get("semver");
-    expect(semver).toEqual([
-      {
-        importerKey: ".",
-        depType: "dependencies",
-        specifier: "^7.0.0",
-        resolvedVersion: "7.7.4",
-      },
-    ]);
-    const ts = lf.directRequirements.get("typescript");
-    expect(ts).toEqual([
-      {
-        importerKey: ".",
-        depType: "devDependencies",
-        specifier: "6.0.3",
-        resolvedVersion: "6.0.3",
-      },
-    ]);
+    expect(lf.importerPaths).toEqual(["."]);
+  });
+
+  it("collects every importer key (including empty importers)", () => {
+    const content = `lockfileVersion: '9.0'
+
+importers:
+
+  .: {}
+
+  packages/a:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.0.0
+
+  packages/b: {}
+`;
+    const lf = parseLockfile(content);
+    expect(lf.importerPaths).toEqual([".", "packages/a", "packages/b"]);
   });
 
   it("collects transitive parents from snapshots dependencies", () => {
@@ -149,29 +151,6 @@ describe("parseLockfile", () => {
     const parents = lf.transitiveParents.get("optionaldep");
     expect(parents).toEqual([
       { parentKey: "speech-rule-engine@4.1.4", resolvedVersion: "1.2.3" },
-    ]);
-  });
-
-  it("strips peer decorations from importer resolved version", () => {
-    const lockfile = `lockfileVersion: '9.0'
-
-importers:
-  .:
-    dependencies:
-      foo:
-        specifier: 1.0.0
-        version: 1.0.0(peer@2.0.0)
-
-snapshots: {}
-`;
-    const lf = parseLockfile(lockfile);
-    expect(lf.directRequirements.get("foo")).toEqual([
-      {
-        importerKey: ".",
-        depType: "dependencies",
-        specifier: "1.0.0",
-        resolvedVersion: "1.0.0",
-      },
     ]);
   });
 
@@ -227,56 +206,10 @@ snapshots: {}
     expect(() => parseLockfile("- a\n- b\n")).toThrow(MalformedLockfileError);
   });
 
-  it("returns empty maps when importers and snapshots are absent", () => {
+  it("returns empty transitive parents when snapshots are absent", () => {
     const lf = parseLockfile("lockfileVersion: '9.0'\n");
-    expect(lf.directRequirements.size).toBe(0);
     expect(lf.transitiveParents.size).toBe(0);
-  });
-
-  it("ignores importers entries that are not mappings", () => {
-    const lockfile = `lockfileVersion: '9.0'
-importers:
-  .: invalid-string-instead-of-map
-`;
-    const lf = parseLockfile(lockfile);
-    expect(lf.directRequirements.size).toBe(0);
-  });
-
-  it("ignores dep-type fields whose value is not a mapping", () => {
-    const lockfile = `lockfileVersion: '9.0'
-importers:
-  .:
-    dependencies: not-a-map
-`;
-    const lf = parseLockfile(lockfile);
-    expect(lf.directRequirements.size).toBe(0);
-  });
-
-  it("ignores dep entries that are not mappings", () => {
-    const lockfile = `lockfileVersion: '9.0'
-importers:
-  .:
-    dependencies:
-      foo: just-a-string
-`;
-    const lf = parseLockfile(lockfile);
-    expect(lf.directRequirements.size).toBe(0);
-  });
-
-  it("ignores dep entries with non-string specifier or version", () => {
-    const lockfile = `lockfileVersion: '9.0'
-importers:
-  .:
-    dependencies:
-      foo:
-        specifier: 1.0.0
-        version: 1
-      bar:
-        specifier: 2
-        version: 2.0.0
-`;
-    const lf = parseLockfile(lockfile);
-    expect(lf.directRequirements.size).toBe(0);
+    expect(lf.importerPaths).toEqual([]);
   });
 
   it("ignores snapshot entries that are not mappings", () => {

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  buildWorkspaceDirectDeps,
   MalformedManifestError,
   parsePackageJsonOverrides,
   parseWorkspaceOverrides,
@@ -189,6 +190,65 @@ describe("parseWorkspaceOverrides", () => {
   it("throws MalformedManifestError on invalid YAML", () => {
     expect(() =>
       parseWorkspaceOverrides(": : :\n  bad:\n indent", "pnpm-workspace.yaml"),
+    ).toThrow(MalformedManifestError);
+  });
+});
+
+describe("buildWorkspaceDirectDeps", () => {
+  it("collects direct deps across all importer fields, indexed by name", () => {
+    const root = JSON.stringify({
+      dependencies: { foo: "^1.0.0" },
+      devDependencies: { bar: "2.0.0" },
+      peerDependencies: { baz: ">=3.0.0" },
+      optionalDependencies: { qux: "^4.0.0" },
+    });
+    const result = buildWorkspaceDirectDeps(new Map([[".", root]]));
+    expect(result.get("foo")).toEqual([
+      { importerKey: ".", depType: "dependencies", spec: "^1.0.0" },
+    ]);
+    expect(result.get("bar")).toEqual([
+      { importerKey: ".", depType: "devDependencies", spec: "2.0.0" },
+    ]);
+    expect(result.get("baz")).toEqual([
+      { importerKey: ".", depType: "peerDependencies", spec: ">=3.0.0" },
+    ]);
+    expect(result.get("qux")).toEqual([
+      { importerKey: ".", depType: "optionalDependencies", spec: "^4.0.0" },
+    ]);
+  });
+
+  it("merges entries from multiple importers under the same target name", () => {
+    const a = JSON.stringify({ dependencies: { foo: "1.0.0" } });
+    const b = JSON.stringify({ devDependencies: { foo: "2.0.0" } });
+    const result = buildWorkspaceDirectDeps(
+      new Map([
+        ["packages/a", a],
+        ["packages/b", b],
+      ]),
+    );
+    expect(result.get("foo")).toEqual([
+      { importerKey: "packages/a", depType: "dependencies", spec: "1.0.0" },
+      { importerKey: "packages/b", depType: "devDependencies", spec: "2.0.0" },
+    ]);
+  });
+
+  it("ignores non-string spec values", () => {
+    const content = JSON.stringify({
+      dependencies: { good: "1.0.0", bad: 42 },
+    });
+    const result = buildWorkspaceDirectDeps(new Map([[".", content]]));
+    expect(result.get("good")).toBeDefined();
+    expect(result.get("bad")).toBeUndefined();
+  });
+
+  it("ignores importers whose root is not an object", () => {
+    const result = buildWorkspaceDirectDeps(new Map([[".", "[]"]]));
+    expect(result.size).toBe(0);
+  });
+
+  it("throws MalformedManifestError on invalid JSON", () => {
+    expect(() =>
+      buildWorkspaceDirectDeps(new Map([[".", "{not json"]])),
     ).toThrow(MalformedManifestError);
   });
 });

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import type { Lockfile } from "../src/lockfile.ts";
-import type { Override } from "../src/manifest.ts";
+import type {
+  DirectDep,
+  Override,
+  WorkspaceDirectDeps,
+} from "../src/manifest.ts";
 import {
   collectNeededRegistryPackages,
   collectPackagesForOverride,
@@ -10,28 +14,8 @@ import {
 import type { PackageMetadata } from "../src/registry.ts";
 
 function makeLockfile(args: {
-  direct?: Record<string, { specifier: string; version: string }>;
   transitive?: Record<string, Array<{ parent: string; resolved: string }>>;
 }): Lockfile {
-  const directMap = new Map<
-    string,
-    {
-      importerKey: string;
-      depType: "dependencies";
-      specifier: string;
-      resolvedVersion: string;
-    }[]
-  >();
-  for (const [name, dep] of Object.entries(args.direct ?? {})) {
-    directMap.set(name, [
-      {
-        importerKey: ".",
-        depType: "dependencies",
-        specifier: dep.specifier,
-        resolvedVersion: dep.version,
-      },
-    ]);
-  }
   const transMap = new Map<
     string,
     { parentKey: string; resolvedVersion: string }[]
@@ -47,10 +31,22 @@ function makeLockfile(args: {
   }
   return {
     version: "9.0",
-    directRequirements: directMap,
+    importerPaths: ["."],
     transitiveParents: transMap,
   };
 }
+
+function makeWorkspaceDirectDeps(
+  args: Record<string, string>,
+): WorkspaceDirectDeps {
+  const map = new Map<string, DirectDep[]>();
+  for (const [name, spec] of Object.entries(args)) {
+    map.set(name, [{ importerKey: ".", depType: "dependencies", spec }]);
+  }
+  return map;
+}
+
+const NO_DIRECT: WorkspaceDirectDeps = new Map();
 
 function makeMetadata(
   name: string,
@@ -76,13 +72,20 @@ const PKG_OVERRIDE = (key: string, spec: string): Override => ({
 });
 
 describe("gatherSpecsForTarget", () => {
-  it("collects specifiers from direct requirements", () => {
-    const lockfile = makeLockfile({
-      direct: { foo: { specifier: "^1.0.0", version: "1.5.0" } },
-    });
-    expect(gatherSpecsForTarget("foo", lockfile, new Map())).toEqual([
+  it("collects specs from workspace direct deps", () => {
+    const lockfile = makeLockfile({});
+    const direct = makeWorkspaceDirectDeps({ foo: "^1.0.0" });
+    expect(gatherSpecsForTarget("foo", lockfile, direct, new Map())).toEqual([
       "^1.0.0",
     ]);
+  });
+
+  it("skips workspace direct deps with protocol-prefixed specs", () => {
+    const lockfile = makeLockfile({});
+    const direct = makeWorkspaceDirectDeps({ foo: "workspace:*" });
+    expect(gatherSpecsForTarget("foo", lockfile, direct, new Map())).toEqual(
+      [],
+    );
   });
 
   it("collects specs from transitive parents via registry data", () => {
@@ -98,23 +101,22 @@ describe("gatherSpecsForTarget", () => {
       ["parentA", makeMetadata("parentA", { "1.0.0": { target: ">=1.0.0" } })],
       ["parentB", makeMetadata("parentB", { "2.0.0": { target: "<2.0.0" } })],
     ]);
-    expect(gatherSpecsForTarget("target", lockfile, registry)).toEqual([
-      ">=1.0.0",
-      "<2.0.0",
-    ]);
+    expect(
+      gatherSpecsForTarget("target", lockfile, NO_DIRECT, registry),
+    ).toEqual([">=1.0.0", "<2.0.0"]);
   });
 
   it("combines direct and transitive specs", () => {
     const lockfile = makeLockfile({
-      direct: { target: { specifier: "^1.0.0", version: "1.5.0" } },
       transitive: {
         target: [{ parent: "parentA@1.0.0", resolved: "1.5.0" }],
       },
     });
+    const direct = makeWorkspaceDirectDeps({ target: "^1.0.0" });
     const registry = new Map<string, PackageMetadata>([
       ["parentA", makeMetadata("parentA", { "1.0.0": { target: ">=1.2.0" } })],
     ]);
-    expect(gatherSpecsForTarget("target", lockfile, registry)).toEqual([
+    expect(gatherSpecsForTarget("target", lockfile, direct, registry)).toEqual([
       "^1.0.0",
       ">=1.2.0",
     ]);
@@ -126,7 +128,9 @@ describe("gatherSpecsForTarget", () => {
         target: [{ parent: "no-at-sign", resolved: "1.0.0" }],
       },
     });
-    expect(gatherSpecsForTarget("target", lockfile, new Map())).toEqual([]);
+    expect(
+      gatherSpecsForTarget("target", lockfile, NO_DIRECT, new Map()),
+    ).toEqual([]);
   });
 
   it("skips parents whose registry metadata is missing", () => {
@@ -135,7 +139,9 @@ describe("gatherSpecsForTarget", () => {
         target: [{ parent: "parentA@1.0.0", resolved: "1.0.0" }],
       },
     });
-    expect(gatherSpecsForTarget("target", lockfile, new Map())).toEqual([]);
+    expect(
+      gatherSpecsForTarget("target", lockfile, NO_DIRECT, new Map()),
+    ).toEqual([]);
   });
 
   it("skips parents whose version meta is missing", () => {
@@ -147,7 +153,9 @@ describe("gatherSpecsForTarget", () => {
     const registry = new Map<string, PackageMetadata>([
       ["parentA", makeMetadata("parentA", { "1.0.0": { target: ">=1.0.0" } })],
     ]);
-    expect(gatherSpecsForTarget("target", lockfile, registry)).toEqual([]);
+    expect(
+      gatherSpecsForTarget("target", lockfile, NO_DIRECT, registry),
+    ).toEqual([]);
   });
 
   it("skips parents that don't list the target in their dependencies", () => {
@@ -159,12 +167,14 @@ describe("gatherSpecsForTarget", () => {
     const registry = new Map<string, PackageMetadata>([
       ["parentA", makeMetadata("parentA", { "1.0.0": { other: ">=1.0.0" } })],
     ]);
-    expect(gatherSpecsForTarget("target", lockfile, registry)).toEqual([]);
+    expect(
+      gatherSpecsForTarget("target", lockfile, NO_DIRECT, registry),
+    ).toEqual([]);
   });
 
   it("returns empty array when target is not present anywhere", () => {
     expect(
-      gatherSpecsForTarget("missing", makeLockfile({}), new Map()),
+      gatherSpecsForTarget("missing", makeLockfile({}), NO_DIRECT, new Map()),
     ).toEqual([]);
   });
 });
@@ -174,6 +184,7 @@ describe("evaluateOverride", () => {
     const result = evaluateOverride(
       PKG_OVERRIDE("foo>bar", ">=1.0.0"),
       makeLockfile({}),
+      NO_DIRECT,
       new Map(),
     );
     expect(result).toEqual({ status: "skip", value: "(nested key)" });
@@ -183,6 +194,7 @@ describe("evaluateOverride", () => {
     const result = evaluateOverride(
       PKG_OVERRIDE("foo", "catalog:default"),
       makeLockfile({}),
+      NO_DIRECT,
       new Map(),
     );
     expect(result).toEqual({ status: "skip", value: "(protocol spec)" });
@@ -192,6 +204,7 @@ describe("evaluateOverride", () => {
     const result = evaluateOverride(
       PKG_OVERRIDE("foo", "^1.0.0"),
       makeLockfile({}),
+      NO_DIRECT,
       new Map(),
     );
     expect(result).toEqual({ status: "skip", value: "(non-lower-bound)" });
@@ -201,6 +214,7 @@ describe("evaluateOverride", () => {
     const result = evaluateOverride(
       PKG_OVERRIDE("foo", ">=1.0.0"),
       makeLockfile({}),
+      NO_DIRECT,
       new Map(),
     );
     expect(result).toEqual({ status: "prune", value: "(unused)" });
@@ -218,6 +232,7 @@ describe("evaluateOverride", () => {
     const result = evaluateOverride(
       PKG_OVERRIDE("foo", ">=1.0.0"),
       lockfile,
+      NO_DIRECT,
       registry,
     );
     expect(result).toEqual({ status: "error", value: "(registry miss)" });
@@ -243,6 +258,7 @@ describe("evaluateOverride", () => {
     const result = evaluateOverride(
       PKG_OVERRIDE("foo", ">=2.0.0"),
       lockfile,
+      NO_DIRECT,
       registry,
     );
     expect(result).toEqual({ status: "prune", value: "2.5.0" });
@@ -268,9 +284,103 @@ describe("evaluateOverride", () => {
     const result = evaluateOverride(
       PKG_OVERRIDE("foo", ">=2.0.0"),
       lockfile,
+      NO_DIRECT,
       registry,
     );
     expect(result).toEqual({ status: "keep", value: "1.5.0" });
+  });
+
+  it("uses workspace direct dep spec to evaluate the override floor", () => {
+    const lockfile = makeLockfile({});
+    const direct = makeWorkspaceDirectDeps({ foo: "^2.0.0" });
+    const registry = new Map<string, PackageMetadata>([
+      [
+        "foo",
+        makeMetadata("foo", {
+          "1.0.0": {},
+          "2.0.0": {},
+          "2.5.0": {},
+        }),
+      ],
+    ]);
+    const result = evaluateOverride(
+      PKG_OVERRIDE("foo", ">=2.0.0"),
+      lockfile,
+      direct,
+      registry,
+    );
+    expect(result).toEqual({ status: "prune", value: "2.5.0" });
+  });
+
+  it("keeps when workspace direct dep spec resolves below the override floor", () => {
+    const lockfile = makeLockfile({});
+    const direct = makeWorkspaceDirectDeps({ foo: "1.0.0" });
+    const registry = new Map<string, PackageMetadata>([
+      [
+        "foo",
+        makeMetadata("foo", {
+          "1.0.0": {},
+          "1.5.0": {},
+          "2.0.0": {},
+        }),
+      ],
+    ]);
+    const result = evaluateOverride(
+      PKG_OVERRIDE("foo", ">=2.0.0"),
+      lockfile,
+      direct,
+      registry,
+    );
+    expect(result).toEqual({ status: "keep", value: "1.0.0" });
+  });
+
+  it("treats target as unused when only direct dep spec is protocol-prefixed", () => {
+    const lockfile = makeLockfile({});
+    const direct = makeWorkspaceDirectDeps({ foo: "workspace:*" });
+    const result = evaluateOverride(
+      PKG_OVERRIDE("foo", ">=1.0.0"),
+      lockfile,
+      direct,
+      new Map(),
+    );
+    expect(result).toEqual({ status: "prune", value: "(unused)" });
+  });
+
+  it("skips versioned keys", () => {
+    const result = evaluateOverride(
+      PKG_OVERRIDE("ajv@^8.0.0", ">=8.18.0"),
+      makeLockfile({}),
+      NO_DIRECT,
+      new Map(),
+    );
+    expect(result).toEqual({ status: "skip", value: "(versioned key)" });
+  });
+
+  it("keeps when conflicting specs would force a per-importer downgrade", () => {
+    const lockfile = makeLockfile({
+      transitive: {
+        foo: [{ parent: "parentA@1.0.0", resolved: "1.5.0" }],
+      },
+    });
+    const direct = makeWorkspaceDirectDeps({ foo: "1.0.0" });
+    const registry = new Map<string, PackageMetadata>([
+      ["parentA", makeMetadata("parentA", { "1.0.0": { foo: "^1.5.0" } })],
+      [
+        "foo",
+        makeMetadata("foo", {
+          "1.0.0": {},
+          "1.5.0": {},
+          "2.0.0": {},
+        }),
+      ],
+    ]);
+    const result = evaluateOverride(
+      PKG_OVERRIDE("foo", ">=2.0.0"),
+      lockfile,
+      direct,
+      registry,
+    );
+    expect(result).toEqual({ status: "keep", value: "1.0.0" });
   });
 });
 

--- a/tests/resolve.test.ts
+++ b/tests/resolve.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { computeNaturalResolution } from "../src/resolve.ts";
 
 describe("computeNaturalResolution", () => {
-  it("returns the max version satisfying all parent specs", () => {
+  it("returns the lowest of per-spec max-satisfying versions", () => {
     expect(
       computeNaturalResolution(
         [">=1.0.0", "<3.0.0"],
@@ -11,13 +11,24 @@ describe("computeNaturalResolution", () => {
     ).toBe("2.0.0");
   });
 
-  it("intersects caret and tilde ranges correctly", () => {
+  it("returns the lowest when caret and tilde ranges disagree", () => {
     expect(
       computeNaturalResolution(
         ["^1.2.3", "~1.5.0"],
         ["1.4.0", "1.5.5", "1.5.9", "1.6.0", "2.0.0"],
       ),
     ).toBe("1.5.9");
+  });
+
+  it("returns the lowest version when exact pins disagree", () => {
+    // Specs '1.19.0' and '1.19.11' can't be hoisted to a single version.
+    // pnpm would install both; the worst case for any consumer is 1.19.0.
+    expect(
+      computeNaturalResolution(
+        ["1.19.0", "1.19.11"],
+        ["1.19.0", "1.19.11", "1.19.13"],
+      ),
+    ).toBe("1.19.0");
   });
 
   it("returns null when no parent specs are given", () => {
@@ -28,10 +39,19 @@ describe("computeNaturalResolution", () => {
     expect(computeNaturalResolution([">=1.0.0"], [])).toBeNull();
   });
 
-  it("returns null when no candidate satisfies the intersection", () => {
+  it("returns null when no candidate satisfies any spec", () => {
     expect(
       computeNaturalResolution([">=10.0.0"], ["1.0.0", "2.0.0"]),
     ).toBeNull();
+  });
+
+  it("skips specs that have no satisfying candidate but uses the rest", () => {
+    expect(
+      computeNaturalResolution(
+        [">=10.0.0", "^1.0.0"],
+        ["1.0.0", "1.5.0", "2.0.0"],
+      ),
+    ).toBe("1.5.0");
   });
 
   it("handles a single spec correctly", () => {


### PR DESCRIPTION
## Summary

- Read workspace package.json specs as constraints instead of lockfile importer specifiers. pnpm rewrites those to the override value, so they cannot be used to decide "what would resolve without the override". The previously reported `(unused)` for direct-dep + override duplicates (e.g. prisma's `@hono/node-server`) was incorrect because of this.
- Switch to per-spec lowest natural resolution. The reported version is the worst case some consumer would land on if the override were removed; `[PRUNE]` only fires when every consumer would still meet the floor.
- Skip versioned-key overrides like `"ajv@^8.0.0": ">=8.18.0"` with reason `(versioned key)`. These combine a selector and a replacement that don't have a safe transformation expressible in pnpm syntax (rewriting to `"ajv": "^8.0.0"` would change which consumers are affected), so the verdict is left for human review.

## Verification

Tested against `prisma/prisma` (real-world, large monorepo with 10 override entries):

```
[PRUNE] form-data >=4.0.4                          4.0.5
[KEEP]  hono >=4.12.14                             4.11.7
[KEEP]  @hono/node-server >=1.19.13                1.19.0
[KEEP]  jws >=4.0.1                                3.2.3
[PRUNE] tar-fs >=2.1.4                             2.1.4
[PRUNE] lodash >=4.17.23                           4.17.23
[KEEP]  @tootallnate/once >=3.0.1                  1.1.2
[SKIP]  ajv@^8.0.0 >=8.18.0                        (versioned key)
[SKIP]  @azure/core-rest-pipeline@^1.0.0 >=1.14.0  (versioned key)
[SKIP]  @azure/msal-node>uuid >=14.0.0             (nested key)
```

`--fix` correctly removes only the three `[PRUNE]` entries, preserving `[KEEP]` and `[SKIP]` (including versioned keys and the scoped name `@hono/node-server`).