### PR TITLE
feat: evaluate versioned-key overrides instead of skipping them

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ For each spec it computes the highest published version that spec would resolve 
   - `pnpm-workspace.yaml` or `aube-workspace.yaml` &rarr; top-level `overrides:`
 - When a key appears in both `pnpm.overrides` and top-level `overrides`, both are reported independently. pnpm gives `pnpm.overrides` precedence at install time, but stale duplicates in the other location are easy to overlook.
 - Only specifiers using `>=` and/or `>` are checked. Exact pins (`1.2.3`), caret (`^1.2.3`), tilde (`~1.2.3`), and bounded ranges are skipped — removing an intentional upper bound is unsafe.
+- Versioned keys like `"glob-parent@<5.1.2": ">=5.1.2"` (the form `pnpm audit --fix` typically emits) are evaluated. The selector is matched against each parent's requested spec via [`semver.intersects`](https://github.com/npm/node-semver#ranges-1) — the rule pnpm itself uses since [pnpm/pnpm#6904](https://github.com/pnpm/pnpm/pull/6904).
 - Lockfile must be `pnpm-lock.yaml` or `aube-lock.yaml` at `lockfileVersion: '9.0'` (pnpm 9+ / aube). Older formats are not supported in this release.
 
 ## Known limitations
 
 - Skips values using non-semver protocols (`catalog:`, `workspace:`, `file:`, `link:`, `portal:`, `npm:`, `github:`, `git`-prefixed, `http:` / `https:`).
 - Skips nested-key overrides like `"parent>child": "1.2.3"`. Only flat `name &rarr; spec` mappings are evaluated.
-- Skips versioned keys like `"ajv@^8.0.0": ">=8.18.0"`. Such entries combine a selector and a replacement; safely transforming them is not expressible in pnpm syntax, so the verdict is left for human review.
+- Skips versioned keys whose selector isn't a parseable semver range (e.g., `"foo@latest": ">=1.0.0"`). pnpm itself falls back to literal-string matching for such selectors, so they're rarely effective; verdict is left for human review.
+- Each override entry is evaluated independently. When multiple entries target the same package (e.g., several `lodash@...` rows from cumulative `pnpm audit --fix` runs), the tool won't propose consolidating them into a single stronger entry — it only marks each one prunable when its own selector/spec combination is a no-op against the natural resolution.
 - Public npm registry only. Private registries and `.npmrc` scoped registry configuration are not consulted.
 - Parents that aren't on the public registry — e.g. workspace-internal packages resolved as transitive parents — are silently dropped from the constraint set. The natural resolution may then appear less constrained than it actually is.
 

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -37,14 +37,48 @@ export function isPureLowerBound(spec: string): boolean {
 }
 
 export function isNestedKey(key: string): boolean {
-  return key.includes(">");
+  // pnpm's nested form is "parent[@version]>child". The separator '>' is
+  // followed by a package-name token, never by '=' (that's the '>='
+  // comparator) or a digit/space (that's a '>X' comparator inside a range).
+  let i = 0;
+  while (i < key.length) {
+    const idx = key.indexOf(">", i);
+    if (idx === -1) {
+      return false;
+    }
+    const next = key[idx + 1];
+    if (
+      next !== undefined &&
+      (next === "=" || next === " " || (next >= "0" && next <= "9"))
+    ) {
+      i = idx + 1;
+      continue;
+    }
+    return true;
+  }
+  return false;
 }
 
-export function isVersionedKey(key: string): boolean {
-  // Detect keys carrying a version constraint, e.g. "ajv@^8.0.0" or
-  // "@scope/pkg@^1.0.0". For "@scope/pkg" the only "@" is the scope marker
-  // at index 0, so we require the separator to appear after position 0.
-  return key.lastIndexOf("@") > 0;
+export interface ParsedKey {
+  readonly name: string;
+  readonly selectorRaw: string | null;
+}
+
+/**
+ * Split an override key into a bare package name and an optional selector
+ * suffix. For "lodash@<4.17.21" returns { name: "lodash", selectorRaw: "<4.17.21" }.
+ * For "@scope/pkg@^1.0.0" returns { name: "@scope/pkg", selectorRaw: "^1.0.0" }.
+ * For "lodash" returns { name: "lodash", selectorRaw: null }.
+ *
+ * Scoped names start with "@", so we use lastIndexOf to find the selector
+ * separator.
+ */
+export function parseKey(key: string): ParsedKey {
+  const lastAt = key.lastIndexOf("@");
+  if (lastAt <= 0) {
+    return { name: key, selectorRaw: null };
+  }
+  return { name: key.slice(0, lastAt), selectorRaw: key.slice(lastAt + 1) };
 }
 
 export function hasProtocolPrefix(spec: string): boolean {
@@ -53,20 +87,31 @@ export function hasProtocolPrefix(spec: string): boolean {
 
 export type SkipReason =
   | "nested-key"
-  | "versioned-key"
+  | "unsupported-selector"
   | "protocol-spec"
   | "non-lower-bound";
 
 export type Categorization =
-  | { readonly kind: "target"; readonly spec: string }
+  | {
+      readonly kind: "target";
+      readonly name: string;
+      readonly selector: Range | null;
+      readonly spec: string;
+    }
   | { readonly kind: "skip"; readonly reason: SkipReason };
 
 export function categorize(key: string, spec: string): Categorization {
   if (isNestedKey(key)) {
     return { kind: "skip", reason: "nested-key" };
   }
-  if (isVersionedKey(key)) {
-    return { kind: "skip", reason: "versioned-key" };
+  const { name, selectorRaw } = parseKey(key);
+  let selector: Range | null = null;
+  if (selectorRaw !== null) {
+    try {
+      selector = new Range(selectorRaw, { loose: false });
+    } catch {
+      return { kind: "skip", reason: "unsupported-selector" };
+    }
   }
   if (hasProtocolPrefix(spec)) {
     return { kind: "skip", reason: "protocol-spec" };
@@ -74,7 +119,7 @@ export function categorize(key: string, spec: string): Categorization {
   if (!isPureLowerBound(spec)) {
     return { kind: "skip", reason: "non-lower-bound" };
   }
-  return { kind: "target", spec };
+  return { kind: "target", name, selector, spec };
 }
 
 export function classify(spec: string, resolved: string | null): Result {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,3 +1,4 @@
+import { intersects } from "semver";
 import {
   categorize,
   classify,
@@ -19,8 +20,8 @@ function skipReasonToValue(reason: SkipReason): string {
   switch (reason) {
     case "nested-key":
       return "(nested key)";
-    case "versioned-key":
-      return "(versioned key)";
+    case "unsupported-selector":
+      return "(unsupported selector)";
     case "protocol-spec":
       return "(protocol spec)";
     case "non-lower-bound":
@@ -79,16 +80,33 @@ export function evaluateOverride(
   if (cat.kind === "skip") {
     return { status: "skip", value: skipReasonToValue(cat.reason) };
   }
-  const specs = gatherSpecsForTarget(
-    override.key,
+  const allSpecs = gatherSpecsForTarget(
+    cat.name,
     lockfile,
     workspaceDirectDeps,
     registryData,
   );
-  if (specs.length === 0) {
+  if (allSpecs.length === 0) {
     return { status: "prune", value: "(unused)" };
   }
-  const targetMeta = registryData.get(override.key);
+  // pnpm fires a versioned-key override on parents whose requested spec
+  // intersects the selector range (see pnpm/pnpm#6904). Drop parent specs
+  // that don't intersect — the override is inert for them.
+  const selector = cat.selector;
+  const specs =
+    selector === null
+      ? allSpecs
+      : allSpecs.filter((s) => {
+          try {
+            return intersects(s, selector);
+          } catch {
+            return false;
+          }
+        });
+  if (specs.length === 0) {
+    return { status: "prune", value: "(selector miss)" };
+  }
+  const targetMeta = registryData.get(cat.name);
   if (targetMeta === undefined) {
     return { status: "error", value: "(registry miss)" };
   }
@@ -106,8 +124,8 @@ export function collectPackagesForOverride(
     return [];
   }
   const needed = new Set<string>();
-  needed.add(override.key);
-  const parents = lockfile.transitiveParents.get(override.key);
+  needed.add(cat.name);
+  const parents = lockfile.transitiveParents.get(cat.name);
   if (parents !== undefined) {
     for (const parent of parents) {
       const parsed = parseSnapshotKey(parent.parentKey);

--- a/tests/analyze.test.ts
+++ b/tests/analyze.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "bun:test";
+import { Range } from "semver";
 import {
   categorize,
   classify,
   hasProtocolPrefix,
   isNestedKey,
   isPureLowerBound,
-  isVersionedKey,
+  parseKey,
 } from "../src/analyze.ts";
 
 describe("isPureLowerBound", () => {
@@ -57,6 +58,10 @@ describe("isNestedKey", () => {
     expect(isNestedKey("foo>bar")).toBe(true);
   });
 
+  it("recognizes parent@version>child syntax", () => {
+    expect(isNestedKey("qar@1>zoo")).toBe(true);
+  });
+
   it("treats flat name as not nested", () => {
     expect(isNestedKey("foo")).toBe(false);
   });
@@ -64,31 +69,70 @@ describe("isNestedKey", () => {
   it("treats scoped flat name as not nested", () => {
     expect(isNestedKey("@scope/foo")).toBe(false);
   });
+
+  it("treats empty string as not nested", () => {
+    expect(isNestedKey("")).toBe(false);
+  });
+
+  it("does not confuse '>=' comparator inside selector", () => {
+    expect(isNestedKey("lodash@>=4.0.0 <=4.17.22")).toBe(false);
+  });
+
+  it("does not confuse '>X' bare comparator", () => {
+    expect(isNestedKey("lodash@>4.0.0")).toBe(false);
+  });
+
+  it("does not confuse '> X' (space-separated comparator)", () => {
+    expect(isNestedKey("lodash@> 4.0.0")).toBe(false);
+  });
+
+  it("treats trailing '>' as nested (malformed)", () => {
+    expect(isNestedKey("foo>")).toBe(true);
+  });
 });
 
-describe("isVersionedKey", () => {
-  it("treats plain name as not versioned", () => {
-    expect(isVersionedKey("foo")).toBe(false);
+describe("parseKey", () => {
+  it("returns null selector for plain name", () => {
+    expect(parseKey("foo")).toEqual({ name: "foo", selectorRaw: null });
   });
 
-  it("treats scoped name as not versioned", () => {
-    expect(isVersionedKey("@scope/foo")).toBe(false);
+  it("returns null selector for scoped name", () => {
+    expect(parseKey("@scope/foo")).toEqual({
+      name: "@scope/foo",
+      selectorRaw: null,
+    });
   });
 
-  it("recognizes name with caret range", () => {
-    expect(isVersionedKey("ajv@^8.0.0")).toBe(true);
+  it("splits name and selector for caret range", () => {
+    expect(parseKey("ajv@^8.0.0")).toEqual({
+      name: "ajv",
+      selectorRaw: "^8.0.0",
+    });
   });
 
-  it("recognizes scoped name with caret range", () => {
-    expect(isVersionedKey("@azure/core-rest-pipeline@^1.0.0")).toBe(true);
+  it("splits name and selector for scoped + caret range", () => {
+    expect(parseKey("@azure/core-rest-pipeline@^1.0.0")).toEqual({
+      name: "@azure/core-rest-pipeline",
+      selectorRaw: "^1.0.0",
+    });
   });
 
-  it("recognizes name with exact pin", () => {
-    expect(isVersionedKey("foo@1.0.0")).toBe(true);
+  it("splits name and selector for compound range", () => {
+    expect(parseKey("lodash@>=4.0.0 <=4.17.22")).toEqual({
+      name: "lodash",
+      selectorRaw: ">=4.0.0 <=4.17.22",
+    });
   });
 
-  it("treats empty string as not versioned", () => {
-    expect(isVersionedKey("")).toBe(false);
+  it("splits name and selector for exact pin", () => {
+    expect(parseKey("foo@1.0.0")).toEqual({
+      name: "foo",
+      selectorRaw: "1.0.0",
+    });
+  });
+
+  it("treats empty string as plain", () => {
+    expect(parseKey("")).toEqual({ name: "", selectorRaw: null });
   });
 });
 
@@ -145,11 +189,41 @@ describe("hasProtocolPrefix", () => {
 });
 
 describe("categorize", () => {
-  it("targets a pure lower bound on a flat key", () => {
+  it("targets a pure lower bound on a flat key with no selector", () => {
     expect(categorize("foo", ">=1.0.0")).toEqual({
       kind: "target",
+      name: "foo",
+      selector: null,
       spec: ">=1.0.0",
     });
+  });
+
+  it("targets a versioned key with parseable selector", () => {
+    const result = categorize("lodash@<4.17.21", ">=4.17.21");
+    expect(result.kind).toBe("target");
+    if (result.kind === "target") {
+      expect(result.name).toBe("lodash");
+      expect(result.spec).toBe(">=4.17.21");
+      expect(result.selector?.range).toBe(new Range("<4.17.21").range);
+    }
+  });
+
+  it("targets a scoped versioned key", () => {
+    const result = categorize("@azure/core-rest-pipeline@^1.0.0", ">=1.14.0");
+    expect(result.kind).toBe("target");
+    if (result.kind === "target") {
+      expect(result.name).toBe("@azure/core-rest-pipeline");
+      expect(result.selector?.range).toBe(new Range("^1.0.0").range);
+    }
+  });
+
+  it("targets a versioned key with compound selector", () => {
+    const result = categorize("lodash@>=4.0.0 <=4.17.22", ">=4.17.23");
+    expect(result.kind).toBe("target");
+    if (result.kind === "target") {
+      expect(result.name).toBe("lodash");
+      expect(result.selector?.range).toBe(new Range(">=4.0.0 <=4.17.22").range);
+    }
   });
 
   it("skips nested keys", () => {
@@ -159,17 +233,17 @@ describe("categorize", () => {
     });
   });
 
-  it("skips versioned keys", () => {
-    expect(categorize("ajv@^8.0.0", ">=8.18.0")).toEqual({
+  it("skips when selector is a dist-tag", () => {
+    expect(categorize("foo@latest", ">=1.0.0")).toEqual({
       kind: "skip",
-      reason: "versioned-key",
+      reason: "unsupported-selector",
     });
   });
 
-  it("skips scoped versioned keys", () => {
-    expect(categorize("@azure/core-rest-pipeline@^1.0.0", ">=1.14.0")).toEqual({
+  it("skips when selector is non-semver garbage", () => {
+    expect(categorize("foo@my-fork", ">=1.0.0")).toEqual({
       kind: "skip",
-      reason: "versioned-key",
+      reason: "unsupported-selector",
     });
   });
 
@@ -194,6 +268,13 @@ describe("categorize", () => {
     });
   });
 
+  it("skips versioned key with non-lower-bound spec", () => {
+    expect(categorize("lodash@<4.17.21", "^4.17.21")).toEqual({
+      kind: "skip",
+      reason: "non-lower-bound",
+    });
+  });
+
   it("nested-key takes precedence over protocol", () => {
     expect(categorize("foo>bar", "workspace:*")).toEqual({
       kind: "skip",
@@ -201,11 +282,18 @@ describe("categorize", () => {
     });
   });
 
-  it("nested-key takes precedence over versioned-key", () => {
+  it("nested-key takes precedence over selector parse", () => {
     // 'foo>bar@1.0.0' has '>' so it's nested first.
     expect(categorize("foo>bar@1.0.0", ">=1.0.0")).toEqual({
       kind: "skip",
       reason: "nested-key",
+    });
+  });
+
+  it("unsupported-selector takes precedence over protocol-spec", () => {
+    expect(categorize("foo@latest", "catalog:default")).toEqual({
+      kind: "skip",
+      reason: "unsupported-selector",
     });
   });
 

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -346,14 +346,168 @@ describe("evaluateOverride", () => {
     expect(result).toEqual({ status: "prune", value: "(unused)" });
   });
 
-  it("skips versioned keys", () => {
+  it("skips versioned keys with non-semver-range selector", () => {
     const result = evaluateOverride(
-      PKG_OVERRIDE("ajv@^8.0.0", ">=8.18.0"),
+      PKG_OVERRIDE("ajv@latest", ">=8.18.0"),
       makeLockfile({}),
       NO_DIRECT,
       new Map(),
     );
-    expect(result).toEqual({ status: "skip", value: "(versioned key)" });
+    expect(result).toEqual({ status: "skip", value: "(unsupported selector)" });
+  });
+
+  it("prunes versioned key when no parent spec intersects the selector", () => {
+    const lockfile = makeLockfile({});
+    // Workspace requests lodash ^5.0.0; selector is <4.17.21 — disjoint.
+    const direct = makeWorkspaceDirectDeps({ lodash: "^5.0.0" });
+    const registry = new Map<string, PackageMetadata>([
+      ["lodash", makeMetadata("lodash", { "5.0.0": {} })],
+    ]);
+    const result = evaluateOverride(
+      PKG_OVERRIDE("lodash@<4.17.21", ">=4.17.21"),
+      lockfile,
+      direct,
+      registry,
+    );
+    expect(result).toEqual({ status: "prune", value: "(selector miss)" });
+  });
+
+  it("prunes versioned key when the natural resolution under intersecting specs satisfies the spec", () => {
+    // Mirrors the pnpm/pnpm#5949 scenario: parent ^5.0.0 intersects selector
+    // <5.1.2; natural resolution under that parent spec is 5.1.5, which
+    // already meets the override floor >=5.1.2.
+    const lockfile = makeLockfile({});
+    const direct = makeWorkspaceDirectDeps({ "glob-parent": "^5.0.0" });
+    const registry = new Map<string, PackageMetadata>([
+      [
+        "glob-parent",
+        makeMetadata("glob-parent", {
+          "5.0.0": {},
+          "5.1.0": {},
+          "5.1.2": {},
+          "5.1.5": {},
+        }),
+      ],
+    ]);
+    const result = evaluateOverride(
+      PKG_OVERRIDE("glob-parent@<5.1.2", ">=5.1.2"),
+      lockfile,
+      direct,
+      registry,
+    );
+    expect(result).toEqual({ status: "prune", value: "5.1.5" });
+  });
+
+  it("keeps versioned key when intersecting parent's natural resolution falls below the spec", () => {
+    // Parent pinned to 4.17.10 — only 4.17.10 satisfies. Override demands
+    // >=4.17.23; natural is below, so removal would change the lockfile.
+    const lockfile = makeLockfile({});
+    const direct = makeWorkspaceDirectDeps({ lodash: "4.17.10" });
+    const registry = new Map<string, PackageMetadata>([
+      [
+        "lodash",
+        makeMetadata("lodash", {
+          "4.17.10": {},
+          "4.17.23": {},
+        }),
+      ],
+    ]);
+    const result = evaluateOverride(
+      PKG_OVERRIDE("lodash@>=4.0.0 <=4.17.22", ">=4.17.23"),
+      lockfile,
+      direct,
+      registry,
+    );
+    expect(result).toEqual({ status: "keep", value: "4.17.10" });
+  });
+
+  it("treats parent specs that fail intersects() as non-matching (prunes when only such specs remain)", () => {
+    // Registry returns a non-semver parent dep spec (e.g., a git url).
+    // intersects() throws on it; we catch and skip the parent. With no
+    // intersecting parents the override is inert -> selector miss.
+    const lockfile = makeLockfile({
+      transitive: {
+        foo: [{ parent: "parentA@1.0.0", resolved: "1.0.0" }],
+      },
+    });
+    const registry = new Map<string, PackageMetadata>([
+      [
+        "parentA",
+        makeMetadata("parentA", {
+          "1.0.0": { foo: "git+https://example.com/foo.git" },
+        }),
+      ],
+      ["foo", makeMetadata("foo", { "1.0.0": {} })],
+    ]);
+    const result = evaluateOverride(
+      PKG_OVERRIDE("foo@<2.0.0", ">=1.5.0"),
+      lockfile,
+      NO_DIRECT,
+      registry,
+    );
+    expect(result).toEqual({ status: "prune", value: "(selector miss)" });
+  });
+
+  it("evaluates the lodash 6-entry audit-fix pattern against a single dependency tree", () => {
+    // Models the user-flagged scenario where pnpm audit --fix has accreted
+    // multiple overrides for the same package. Workspace requests ^4.0.0;
+    // registry's latest in 4.x is 4.17.21. We expect each entry to fall out
+    // independently per the per-entry rule.
+    const lockfile = makeLockfile({});
+    const direct = makeWorkspaceDirectDeps({ lodash: "^4.0.0" });
+    const registry = new Map<string, PackageMetadata>([
+      [
+        "lodash",
+        makeMetadata("lodash", {
+          "3.10.1": {},
+          "4.0.0": {},
+          "4.17.10": {},
+          "4.17.19": {},
+          "4.17.21": {},
+        }),
+      ],
+    ]);
+    const evaluate = (key: string, spec: string) =>
+      evaluateOverride(PKG_OVERRIDE(key, spec), lockfile, direct, registry);
+    // V = max(^4.0.0) = 4.17.21
+    // Selector <4.17.21: V doesn't satisfy -> override doesn't intersect for parent? Actually
+    // ^4.0.0 (>=4.0.0 <5.0.0) DOES intersect <4.17.21, so per-parent natural is 4.17.21 itself.
+    // 4.17.21 satisfies >=4.17.21 -> PRUNE.
+    expect(evaluate("lodash@<4.17.21", ">=4.17.21")).toEqual({
+      status: "prune",
+      value: "4.17.21",
+    });
+    // Selector >=3.7.0 <4.17.19 intersects ^4.0.0 (>=4.0.0 <4.17.19 region).
+    // Natural under intersecting parent is still max(^4.0.0) = 4.17.21,
+    // which satisfies >=4.17.19 -> PRUNE.
+    expect(evaluate("lodash@>=3.7.0 <4.17.19", ">=4.17.19")).toEqual({
+      status: "prune",
+      value: "4.17.21",
+    });
+    // Selector >=4.0.0 <4.17.21 intersects ^4.0.0; natural 4.17.21
+    // satisfies >=4.17.21 -> PRUNE.
+    expect(evaluate("lodash@>=4.0.0 <4.17.21", ">=4.17.21")).toEqual({
+      status: "prune",
+      value: "4.17.21",
+    });
+    // Selector >=4.0.0 <=4.17.22 intersects ^4.0.0; natural 4.17.21
+    // does NOT satisfy >=4.17.23 -> KEEP.
+    expect(evaluate("lodash@>=4.0.0 <=4.17.22", ">=4.17.23")).toEqual({
+      status: "keep",
+      value: "4.17.21",
+    });
+    // Selector >=4.0.0 <=4.17.23 intersects ^4.0.0; natural 4.17.21
+    // does NOT satisfy >=4.18.0 -> KEEP.
+    expect(evaluate("lodash@>=4.0.0 <=4.17.23", ">=4.18.0")).toEqual({
+      status: "keep",
+      value: "4.17.21",
+    });
+    // Selector <=4.17.23 intersects ^4.0.0; natural 4.17.21 doesn't satisfy
+    // >=4.18.0 -> KEEP.
+    expect(evaluate("lodash@<=4.17.23", ">=4.18.0")).toEqual({
+      status: "keep",
+      value: "4.17.21",
+    });
   });
 
   it("keeps when conflicting specs would force a per-importer downgrade", () => {


### PR DESCRIPTION
## Summary

- Versioned-key overrides such as `"lodash@<4.17.21": ">=4.17.21"` (the form `pnpm audit --fix` typically emits) used to be skipped wholesale as `(versioned key)`. They are now first-class targets when the selector parses as a semver range.
- Parent specs are filtered through `semver.intersects(parentSpec, selector)` before computing natural resolution — this mirrors pnpm's own override-firing rule since pnpm/pnpm#6904.
- The remaining skip reason is renamed `unsupported-selector` and now only fires for selectors that fail `Range` parsing (dist-tags like `foo@latest`, alias forms, etc.). `isNestedKey` was reworked so `>=` / `>X` / `> X` comparators inside selectors aren't mistaken for the `parent>child` separator.