### PR TITLE
chore: install biome via mise (aqua)

### DIFF
--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -5,21 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 time:
-  '@biomejs/biome@2.4.13': 2026-04-23T15:40:57.553Z
-  '@biomejs/cli-darwin-arm64@2.4.13': 2026-04-23T15:41:08.668Z
-  '@biomejs/cli-linux-arm64-musl@2.4.13': 2026-04-23T15:41:33.094Z
-  '@biomejs/cli-linux-arm64@2.4.13': 2026-04-23T15:41:26.398Z
-  '@biomejs/cli-linux-x64-musl@2.4.13': 2026-04-23T15:41:51.908Z
-  '@biomejs/cli-linux-x64@2.4.13': 2026-04-23T15:41:43.305Z
-  '@biomejs/cli-win32-arm64@2.4.13': 2026-04-23T15:42:00.706Z
-  '@biomejs/cli-win32-x64@2.4.13': 2026-04-23T15:42:10.153Z
-  '@types/bun@1.3.13': 2026-04-22T15:55:43.685Z
-  '@types/node@25.6.0': 2026-04-10T03:39:59.421Z
-  '@types/semver@7.7.1': 2025-09-03T15:02:35.366Z
   bun-types@1.3.13: 2026-04-20T08:09:49.687Z
   semver@7.7.4: 2026-02-05T17:23:11.131Z
-  typescript@6.0.3: 2026-04-16T23:38:27.905Z
-  undici-types@7.19.2: 2026-01-27T20:25:15.804Z
   yaml@2.8.3: 2026-03-21T10:37:06.001Z
 
 importers:
@@ -33,9 +20,6 @@ importers:
         specifier: 2.8.3
         version: 2.8.3
     devDependencies:
-      '@biomejs/biome':
-        specifier: 2.4.13
-        version: 2.4.13
       '@types/bun':
         specifier: 1.3.13
         version: 1.3.13
@@ -50,75 +34,6 @@ importers:
         version: 6.0.3
 
 packages:
-
-  '@biomejs/biome@2.4.13':
-    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
-    engines: {node: '>=14.21.3'}
-    hasBin: true
-
-  '@biomejs/cli-darwin-arm64@2.4.13':
-    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
-    engines: {node: '>=14.21.3'}
-    os:
-    - darwin
-    cpu:
-    - arm64
-
-  '@biomejs/cli-linux-arm64-musl@2.4.13':
-    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
-    engines: {node: '>=14.21.3'}
-    os:
-    - linux
-    cpu:
-    - arm64
-    libc:
-    - musl
-
-  '@biomejs/cli-linux-arm64@2.4.13':
-    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
-    engines: {node: '>=14.21.3'}
-    os:
-    - linux
-    cpu:
-    - arm64
-    libc:
-    - glibc
-
-  '@biomejs/cli-linux-x64-musl@2.4.13':
-    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
-    engines: {node: '>=14.21.3'}
-    os:
-    - linux
-    cpu:
-    - x64
-    libc:
-    - musl
-
-  '@biomejs/cli-linux-x64@2.4.13':
-    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
-    engines: {node: '>=14.21.3'}
-    os:
-    - linux
-    cpu:
-    - x64
-    libc:
-    - glibc
-
-  '@biomejs/cli-win32-arm64@2.4.13':
-    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
-    engines: {node: '>=14.21.3'}
-    os:
-    - win32
-    cpu:
-    - arm64
-
-  '@biomejs/cli-win32-x64@2.4.13':
-    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
-    engines: {node: '>=14.21.3'}
-    os:
-    - win32
-    cpu:
-    - x64
 
   '@types/bun@1.3.13':
     resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
@@ -151,30 +66,6 @@ packages:
     hasBin: true
 
 snapshots:
-
-  '@biomejs/biome@2.4.13':
-    optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.13
-      '@biomejs/cli-linux-arm64': 2.4.13
-      '@biomejs/cli-linux-arm64-musl': 2.4.13
-      '@biomejs/cli-linux-x64': 2.4.13
-      '@biomejs/cli-linux-x64-musl': 2.4.13
-      '@biomejs/cli-win32-arm64': 2.4.13
-      '@biomejs/cli-win32-x64': 2.4.13
-
-  '@biomejs/cli-darwin-arm64@2.4.13': {}
-
-  '@biomejs/cli-linux-arm64-musl@2.4.13': {}
-
-  '@biomejs/cli-linux-arm64@2.4.13': {}
-
-  '@biomejs/cli-linux-x64-musl@2.4.13': {}
-
-  '@biomejs/cli-linux-x64@2.4.13': {}
-
-  '@biomejs/cli-win32-arm64@2.4.13': {}
-
-  '@biomejs/cli-win32-x64@2.4.13': {}
 
   '@types/bun@1.3.13':
     dependencies:

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,9 @@ min_version = "2026.4.8"
 install_before = "1d"
 
 [tools]
+# Use the aqua backend (GitHub Releases). The npm-published native
+# binary tarball (@biomejs/cli-* ~30MB) fetches unreliably on CI.
+biome = "2.4.13"
 bun = "1.3.13"
 node = "24.15.0"
 "npm:@endevco/aube" = "1.2.1"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.13",
     "@types/bun": "1.3.13",
     "@types/node": "25.6.0",
     "@types/semver": "7.7.1",

--- a/validate.sh
+++ b/validate.sh
@@ -11,7 +11,7 @@ aube install --frozen-lockfile
 aube licenses
 aube audit --fix --ignore-unfixable
 pnpm-override-prune --fix
-aube exec biome migrate --write
+biome migrate --write
 aube run check:write
 aube run typecheck
 aube run test


### PR DESCRIPTION
## Summary

Move biome from an npm devDependency to mise's aqua backend (GitHub Releases).

## Why

The CI validate job occasionally hits errors like `× failed to fetch @biomejs/cli-linux-x64@2.4.13: HTTP error: error decoding response body`. The npm registry (Cloudflare-fronted) sometimes truncates the TLS stream while serving the ~30MB `@biomejs/cli-*` native binary tarball. aube does retry body-read errors, but three consecutive failures still fail the job.

aqua pulls the binary from GitHub Releases instead, sidestepping that failure mode.

## Changes

- `mise.toml`: add `biome = "2.4.13"` (mise's registry resolves this to the aqua backend)
- `package.json`: remove `@biomejs/biome` from `devDependencies`
- `validate.sh`: replace `aube exec biome migrate --write` with `biome migrate --write` so it uses the biome on PATH

`package.json`'s `check` and `check:write` scripts already invoke `biome` directly, so they continue to work.

## Out of scope

- Other native binaries pulled in transitively (none in this project) are unaffected.
- Renovate's mise manager resolves the unprefixed `biome` short name via `mise registry --json`, so version bumps continue to work automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)