### PR TITLE
chore: use shared shell-lint task

### DIFF
--- a/compatibility.sh
+++ b/compatibility.sh
@@ -15,8 +15,8 @@ TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"; rm -f "$TARBALL"' EXIT
 
 cd "$TMP"
-npm init --silent --yes > /dev/null
+npm init --silent --yes >/dev/null
 npm install --silent --no-audit --no-fund "$TARBALL"
 
 ./node_modules/.bin/pnpm-override-prune --version
-./node_modules/.bin/pnpm-override-prune --help > /dev/null
+./node_modules/.bin/pnpm-override-prune --help >/dev/null

--- a/mise.toml
+++ b/mise.toml
@@ -17,5 +17,5 @@ install_before = "0d"
 
 [task_config]
 includes = [
-  "git::https://github.com/iwamot/mise-tasks.git//.mise/tasks?ref=v1.4.0",
+  "git::https://github.com/iwamot/mise-tasks.git//.mise/tasks?ref=v1.5.0",
 ]

--- a/validate.sh
+++ b/validate.sh
@@ -19,6 +19,7 @@ aube run build
 
 # Run shared lint tasks
 mise run gha-lint
+mise run shell-lint
 
 # Check for uncommitted changes
 git diff --exit-code


### PR DESCRIPTION
## Summary

- Bump `task_config.includes` to `iwamot/mise-tasks@v1.5.0`.
- Add `mise run shell-lint` to `validate.sh`.
- shfmt auto-formatted two redirect operators in `compatibility.sh` (`> /dev/null` → `>/dev/null`); no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)