### PR TITLE
chore: switch validate.sh to aube audit --fix update

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -9,7 +9,7 @@ mise install
 # TypeScript
 aube install --frozen-lockfile
 aube licenses
-aube audit --fix --ignore-unfixable
+aube audit --fix update --ignore-unfixable
 pnpm-override-prune --fix
 biome migrate --write
 aube run check:write


### PR DESCRIPTION
## Summary

- aube 1.4.0 added pnpm-compatible `--fix=update` ([endevco/aube#363](https://github.com/endevco/aube/pull/363)).
- Switch `validate.sh` from override-mode fix to update-mode fix, so vulnerabilities are addressed by lockfile refresh rather than by accumulating `package.json` overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)