### PR TITLE
chore: move biome from mise to npm devDep

### DIFF
--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -5,6 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 time:
+  '@biomejs/biome@2.4.13': 2026-04-23T15:40:57.553Z
+  '@biomejs/cli-darwin-arm64@2.4.13': 2026-04-23T15:41:08.668Z
+  '@biomejs/cli-linux-arm64-musl@2.4.13': 2026-04-23T15:41:33.094Z
+  '@biomejs/cli-linux-arm64@2.4.13': 2026-04-23T15:41:26.398Z
+  '@biomejs/cli-linux-x64-musl@2.4.13': 2026-04-23T15:41:51.908Z
+  '@biomejs/cli-linux-x64@2.4.13': 2026-04-23T15:41:43.305Z
+  '@biomejs/cli-win32-arm64@2.4.13': 2026-04-23T15:42:00.706Z
+  '@biomejs/cli-win32-x64@2.4.13': 2026-04-23T15:42:10.153Z
   bun-types@1.3.13: 2026-04-20T08:09:49.687Z
   semver@7.7.4: 2026-02-05T17:23:11.131Z
   yaml@2.8.3: 2026-03-21T10:37:06.001Z
@@ -20,6 +28,9 @@ importers:
         specifier: 2.8.3
         version: 2.8.3
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.4.13
+        version: 2.4.13
       '@types/bun':
         specifier: 1.3.13
         version: 1.3.13
@@ -34,6 +45,75 @@ importers:
         version: 6.0.3
 
 packages:
+
+  '@biomejs/biome@2.4.13':
+    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - darwin
+    cpu:
+    - arm64
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - win32
+    cpu:
+    - arm64
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - win32
+    cpu:
+    - x64
 
   '@types/bun@1.3.13':
     resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
@@ -66,6 +146,30 @@ packages:
     hasBin: true
 
 snapshots:
+
+  '@biomejs/biome@2.4.13':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64-musl': 2.4.13
+      '@biomejs/cli-linux-x64': 2.4.13
+      '@biomejs/cli-linux-x64-musl': 2.4.13
+      '@biomejs/cli-win32-arm64': 2.4.13
+      '@biomejs/cli-win32-x64': 2.4.13
+
+  '@biomejs/cli-darwin-arm64@2.4.13': {}
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13': {}
+
+  '@biomejs/cli-linux-arm64@2.4.13': {}
+
+  '@biomejs/cli-linux-x64-musl@2.4.13': {}
+
+  '@biomejs/cli-linux-x64@2.4.13': {}
+
+  '@biomejs/cli-win32-arm64@2.4.13': {}
+
+  '@biomejs/cli-win32-x64@2.4.13': {}
 
   '@types/bun@1.3.13':
     dependencies:

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
     "includes": ["src/**", "tests/**"]
   },

--- a/mise.toml
+++ b/mise.toml
@@ -4,9 +4,6 @@ min_version = "2026.4.8"
 install_before = "1d"
 
 [tools]
-# Use the aqua backend (GitHub Releases). The npm-published native
-# binary tarball (@biomejs/cli-* ~30MB) fetches unreliably on CI.
-biome = "2.4.13"
 bun = "1.3.13"
 node = "24.15.0"
 "npm:@endevco/aube" = "1.5.1"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.13",
     "@types/bun": "1.3.13",
     "@types/node": "25.6.0",
     "@types/semver": "7.7.1",

--- a/validate.sh
+++ b/validate.sh
@@ -11,7 +11,6 @@ aube install --frozen-lockfile
 aube licenses
 aube audit --fix update --ignore-unfixable
 aube run prune
-biome migrate --write
 aube run check:write
 aube run typecheck
 aube run test


### PR DESCRIPTION
## Summary

Renovate detects the `$schema` URL in `biome.json` and the biome entry in `mise.toml` through different datasources. When only one side is bumped, CI runs `biome migrate --write`, which rewrites `$schema` back to the binary version, and `git diff --exit-code` fails.

To remove this structural conflict, consolidate biome's version management into package.json:

- Remove biome from `mise.toml`
- Add `@biomejs/biome` as devDep (platform binaries are optional and survive fetch failures)
- Point `biome.json` `$schema` to `./node_modules/@biomejs/biome/configuration_schema.json`
- Drop the now no-op `biome migrate --write` from `validate.sh` (run it manually on biome major bumps)

Schema and binary now stay in sync and Renovate has a single update target for biome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)