### PR TITLE
chore(deps): downgrade @types/node to LTS major (24.x)

### DIFF
--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -13,8 +13,10 @@ time:
   '@biomejs/cli-linux-x64@2.4.13': 2026-04-23T15:41:43.305Z
   '@biomejs/cli-win32-arm64@2.4.13': 2026-04-23T15:42:00.706Z
   '@biomejs/cli-win32-x64@2.4.13': 2026-04-23T15:42:10.153Z
+  '@types/node@24.12.2': 2026-04-03T11:15:02.599Z
   bun-types@1.3.13: 2026-04-20T08:09:49.687Z
   semver@7.7.4: 2026-02-05T17:23:11.131Z
+  undici-types@7.16.0: 2025-09-09T17:07:27.610Z
   yaml@2.8.3: 2026-03-21T10:37:06.001Z
 
 importers:
@@ -35,8 +37,8 @@ importers:
         specifier: 1.3.13
         version: 1.3.13
       '@types/node':
-        specifier: 25.6.0
-        version: 25.6.0
+        specifier: 24.12.2
+        version: 24.12.2
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
@@ -118,6 +120,9 @@ packages:
   '@types/bun@1.3.13':
     resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
 
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
@@ -136,6 +141,9 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -175,6 +183,10 @@ snapshots:
     dependencies:
       bun-types: 1.3.13
 
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
@@ -188,6 +200,8 @@ snapshots:
   semver@7.7.4: {}
 
   typescript@6.0.3: {}
+
+  undici-types@7.16.0: {}
 
   undici-types@7.19.2: {}
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.13",
     "@types/bun": "1.3.13",
-    "@types/node": "25.6.0",
+    "@types/node": "24.12.2",
     "@types/semver": "7.7.1",
     "typescript": "6.0.3"
   }


### PR DESCRIPTION
## Summary

The initial commit pinned `@types/node` to `25.6.0` because npm's `latest` dist-tag pointed at the non-LTS 25 line at the time of `aube add -D @types/node`. Renovate's `versioning: "node"` (via `workarounds:typesNodeVersioning` extended through `iwamot/renovate-config`) blocks future bumps to non-LTS majors but does not downgrade an existing pin, so the 25.x version persisted.

Re-pin to `24.12.2` (current Node 24 LTS line) to align with the mise runtime (`node = "24.15.0"`) and let the existing preset maintain LTS-only updates from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)