### PR TITLE
chore: restrict workflow-level permissions to {} and grant per job

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -6,11 +6,12 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   compatibility:
+    permissions:
+      contents: read
     uses: iwamot/workflows/.github/workflows/compatibility-node.yml@d1fbf4d009ef835741c9801626f014ef90a7dac2 # v1.4.0
     with:
       node-versions: '["20","22","24"]'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,10 +1,11 @@
 name: Dependabot auto-merge
 on: pull_request
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   dependabot-auto-merge:
+    permissions:
+      contents: write       # to merge auto-merge PRs
+      pull-requests: write  # to enable auto-merge
     uses: iwamot/workflows/.github/workflows/dependabot-auto-merge.yml@d1fbf4d009ef835741c9801626f014ef90a7dac2 # v1.4.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,10 +3,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   dependency-review:
+    permissions:
+      contents: read
+      pull-requests: write  # to comment review summary
     uses: iwamot/workflows/.github/workflows/dependency-review.yml@d1fbf4d009ef835741c9801626f014ef90a7dac2 # v1.4.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,16 +4,20 @@ on:
   push:
     tags: ['v*.*.*']
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish-npm:
+    name: publish-npm
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production
     permissions:
       contents: read
-      id-token: write
+      id-token: write  # for npm Trusted Publishing OIDC
     steps:
       - uses: iwamot/actions/npm-publish@792bb6f7b66b5d046aa285d39303a0aa7b10f822 # v0.5.0

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,11 +15,12 @@ on:
           - info
           - debug
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   renovate:
+    permissions:
+      contents: read
     uses: iwamot/workflows/.github/workflows/renovate.yml@d1fbf4d009ef835741c9801626f014ef90a7dac2 # v1.4.0
     with:
       log-level: ${{ inputs.log-level || 'info' }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,12 +6,11 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   validate:
     permissions:
       contents: read
-      id-token: write
+      id-token: write  # for Codecov OIDC upload
     uses: iwamot/workflows/.github/workflows/validate-with-coverage.yml@d1fbf4d009ef835741c9801626f014ef90a7dac2 # v1.4.0


### PR DESCRIPTION
## Summary

- Set workflow-level \`permissions: {}\` to deny by default and grant only the necessary permissions per job, following least-privilege.
- Add explanatory comments to every write-level permission so the intent is recorded inline.
- Add a workflow-level \`concurrency:\` block to \`publish.yml\` and an explicit \`name:\` to its job.
- Detected by zizmor's \`--pedantic\` audits \`excessive-permissions\`, \`undocumented-permissions\`, \`concurrency-limits\`, and \`anonymous-definition\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)