### PR TITLE
chore(deps): migrate oide.yml to iwamot/workflows v3.2.0

### DIFF
--- a/.github/workflows/oide.yml
+++ b/.github/workflows/oide.yml
@@ -1,4 +1,4 @@
-name: oide
+name: Oide
 
 on:
   workflow_dispatch:
@@ -12,6 +12,8 @@ permissions: {}
 jobs:
   pull:
     permissions:
-      contents: write       # to push the branch
-      pull-requests: write  # to open the PR
-    uses: iwamot/workflows/.github/workflows/oide.yml@69e4e95359ec485551da77d06323ecc3d9c956a9 # v2.0.0
+      contents: read
+    uses: iwamot/workflows/.github/workflows/oide.yml@7b3c075718bd3e57a5316384ef1184ab931ef847 # v3.2.0
+    secrets:
+      RENOVATE_APP_ID: ${{ secrets.RENOVATE_APP_ID }}
+      RENOVATE_PRIVATE_KEY: ${{ secrets.RENOVATE_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Migrate `.github/workflows/oide.yml` from [iwamot/workflows](https://github.com/iwamot/workflows) v2.0.0 to v3.2.0, in one PR (cleanly replaces the open Renovate ref-bump PR which can't represent the full migration).

## Changes

- Bump `uses` ref to v3.2.0
- Pass `RENOVATE_APP_ID` / `RENOVATE_PRIVATE_KEY` secrets (required from v3)
- Drop `contents: write` / `pull-requests: write` from the caller's job — the reusable workflow now uses a GitHub App installation token internally
- Capitalize the workflow `name` to `Oide`

## Why

v3.0.0 was a breaking change (added required `secrets`). The plain Renovate PR could only bump the `uses` ref, so merging it alone would have left the workflow broken (missing secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
