### PR TITLE
chore: prune unused .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,36 +3,12 @@ dist/
 
 # Dependencies
 node_modules/
-.pnpm-debug.log*
 
 # Coverage
 coverage/
-*.lcov
-
-# IDE
-.vscode/
-.idea/
-*.swp
-*.swo
-*~
 
 # Claude Code
 .claude/
 
-# OS
-.DS_Store
-Thumbs.db
-
-# Environment
-.env
-.env.local
-.env.*.local
-
-# Logs
-*.log
-logs/
-
 # Temporary files
 *.tmp
-*.temp
-.cache/


### PR DESCRIPTION
## Summary

Drop defensive `.gitignore` patterns that don't match anything in the working tree.

**Removed**
- IDE: `.vscode/`, `.idea/`
- Editor swap: `*.swp`, `*.swo`, `*~`
- OS artifact: `.DS_Store`, `Thumbs.db`
- Env defense: `.env`, `.env.local`, `.env.*.local`
- Misc: `*.lcov`, `.pnpm-debug.log*`, `*.log`, `logs/`, `*.temp`, `.cache/`

Empty section header comments (`# IDE`, `# OS`, `# Environment`, `# Logs`) are removed in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)