### PR TITLE
chore: unify release flow via iwamot/actions composites

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Release
 
 on:
   push:
@@ -8,16 +8,18 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  publish-npm:
-    name: publish-npm
+  release:
+    name: release
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production
     permissions:
-      contents: read
+      contents: write  # to manage the GitHub Release lifecycle
       id-token: write  # for npm Trusted Publishing OIDC
     steps:
+      - uses: iwamot/actions/release-draft@08456ce23ea73c42a50d71bd5a067d5ad68dc7e9 # v0.7.0
       - uses: iwamot/actions/npm-publish@08456ce23ea73c42a50d71bd5a067d5ad68dc7e9 # v0.7.0
+      - uses: iwamot/actions/release-publish@08456ce23ea73c42a50d71bd5a067d5ad68dc7e9 # v0.7.0


### PR DESCRIPTION
## Summary

- Rename `publish.yml` to `release.yml` and wrap the existing `iwamot/actions/npm-publish` step between `release-draft` (creates draft GitHub Release with auto-notes) and `release-publish` (flips to published).
- All three composites pinned to `iwamot/actions@v0.7.0`. The middle step still runs in the caller's job to keep npm Trusted Publishing's `job_workflow_ref` pointing at this caller.
- Set `cancel-in-progress: false` to match the unified release flow used by other iwamot/* repos (avoid interrupting a publish mid-run).
- `permissions.contents: read` → `write` to allow `release-draft` / `release-publish` to manage the Release lifecycle. `id-token: write` retained for OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)