### PR TITLE
chore: smoke-test npm publish in validate.sh

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -15,6 +15,8 @@ aube run check:write
 aube run typecheck
 aube run test
 aube run build
+# --no-git-checks lets the dry-run run on any branch (publish itself would still gate on main).
+aube publish --dry-run --no-git-checks
 
 # Run shared lint tasks
 mise run gha-lint


### PR DESCRIPTION
## Summary

- Add `aube publish --dry-run` after the build step in `validate.sh` so npm packaging breakage is caught before tagging a release.
- `--no-git-checks` is needed because aube refuses to run `publish` (even dry-run) outside `main`/`master`; the real `publish` invoked at release time still gates on the branch.
- Unlike `uv publish --dry-run`, aube's dry-run requires no credentials and leaves no tarball behind, so no extra cleanup or placeholder token is needed.