### PR TITLE
chore: switch compatibility.sh to invoke --fix

### DIFF
--- a/compatibility.sh
+++ b/compatibility.sh
@@ -14,9 +14,8 @@ TARBALL="$PWD/$(npm pack --silent)"
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"; rm -f "$TARBALL"' EXIT
 
-cd "$TMP"
-npm init --silent --yes >/dev/null
-npm install --silent --no-audit --no-fund "$TARBALL"
+(cd "$TMP" && npm init --silent --yes >/dev/null &&
+  npm install --silent --no-audit --no-fund "$TARBALL")
 
-./node_modules/.bin/pnpm-override-prune --version
-./node_modules/.bin/pnpm-override-prune --help >/dev/null
+"$TMP/node_modules/.bin/pnpm-override-prune" --version
+"$TMP/node_modules/.bin/pnpm-override-prune" --fix


### PR DESCRIPTION
## Summary
- Replace `--help` smoke check with `--fix` so the compatibility test exercises the prune path used by sibling CLIs (`gitignore-prune`, `uv-override-prune`).
- `--fix` requires `pnpm-lock.yaml` in cwd, so the `npm install` step runs in a subshell — the main script stays at the repo root and invokes the installed binary by absolute path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)