### PR TITLE
docs: trim README badges to npm and node only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # pnpm-override-prune
 
-[![Validate](https://github.com/iwamot/pnpm-override-prune/actions/workflows/validate.yml/badge.svg)](https://github.com/iwamot/pnpm-override-prune/actions/workflows/validate.yml)
-[![codecov](https://codecov.io/gh/iwamot/pnpm-override-prune/graph/badge.svg)](https://codecov.io/gh/iwamot/pnpm-override-prune)
 [![npm](https://img.shields.io/npm/v/pnpm-override-prune.svg)](https://www.npmjs.com/package/pnpm-override-prune)
-[![Node](https://img.shields.io/node/v/pnpm-override-prune.svg)](https://www.npmjs.com/package/pnpm-override-prune)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![node](https://img.shields.io/node/v/pnpm-override-prune.svg)](https://www.npmjs.com/package/pnpm-override-prune)
 
 Detect prunable override entries in pnpm / [aube](https://github.com/endevco/aube) projects.
 


### PR DESCRIPTION
## Summary

- Remove the Validate (CI status), codecov, and License badges from the README header.
- Keep the npm and node badges, which answer the two questions a prospective user actually asks before installing: where the package is published with its latest version, and which Node versions it supports.
- Lowercase the node badge alt text so it matches the rendered badge image (npm was already lowercase).

## Why

CI status and coverage are internal quality signals that don't change a user's install decision. The License badge is more meaningful for libraries that get embedded into a user's bundle; for a CLI like this, license rarely gates the choice to try it, and npm shows the license on the package page anyway.