### PR TITLE
fix!: switch version short flag to -v

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -15,7 +15,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
     const parsed = nodeParseArgs({
       args: [...argv],
       options: {
-        version: { type: "boolean", short: "V" },
+        version: { type: "boolean", short: "v" },
         help: { type: "boolean", short: "h" },
         fix: { type: "boolean" },
       },

--- a/src/format.ts
+++ b/src/format.ts
@@ -72,7 +72,7 @@ export function formatHelp(): string {
     "",
     "Options:",
     "  --fix          Remove prunable entries in place",
-    "  -V, --version  Print the version and exit",
+    "  -v, --version  Print the version and exit",
     "  -h, --help     Print this help and exit",
     "",
   ].join("\n");

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -10,8 +10,8 @@ describe("parseArgs", () => {
     });
   });
 
-  it("recognizes -V as a version request", () => {
-    expect(parseArgs(["-V"])).toEqual({ kind: "version" });
+  it("recognizes -v as a version request", () => {
+    expect(parseArgs(["-v"])).toEqual({ kind: "version" });
   });
 
   it("recognizes --version as a version request", () => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -145,7 +145,7 @@ describe("formatHelp", () => {
     const text = formatHelp();
     expect(text).toContain("Usage: pnpm-override-prune");
     expect(text).toContain("--fix");
-    expect(text).toContain("-V, --version");
+    expect(text).toContain("-v, --version");
     expect(text).toContain("-h, --help");
   });
 });

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "bun:test";
 import { decideRun } from "../src/run.ts";
 
 describe("decideRun", () => {
-  it("returns sync version output for -V", () => {
-    const result = decideRun(["-V"], "1.2.3");
+  it("returns sync version output for -v", () => {
+    const result = decideRun(["-v"], "1.2.3");
     expect(result).toEqual({
       kind: "sync",
       exitCode: 0,


### PR DESCRIPTION
## Summary

- Change the version short flag from `-V` to `-v` to follow the convention used by docker, terraform, hugo, pnpm, etc. `-V` is no longer recognised and exits with `unknown option` (exit 2).
- Mirrors the same change in [iwamot/gitignore-prune#12](https://github.com/iwamot/gitignore-prune/pull/12) for consistency across the `*-prune` family.

## Why

The previous `-V` was an outlier among Go/Node CLIs, which uniformly use lowercase `-v` for version. The mismatch was minor but real friction.

## Breaking change

`-V` is removed. Scripts or CI invocations relying on `pnpm-override-prune -V` need to switch to `-v` (or `--version`). The long form `--version` is unchanged.

## Note on version-string resolution

Unlike gitignore-prune (which needed a `runtime/debug.ReadBuildInfo()` fallback for `go install`), this package reads the version directly from `package.json` and the release pipeline rewrites that field from the git tag before `bun build`, so npm-installed binaries already show the correct version. No additional fallback is needed.