### PR TITLE
chore: restrict pull_request triggers to main branch

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -2,6 +2,7 @@ name: 'Auto label by title'
 on:
   pull_request:
     types: [opened]
+    branches: [ "main" ]
 
 permissions: {}
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary

Add explicit `branches: [ "main" ]` to `pull_request:` triggers in `auto-label.yml`, `validate.yml`, and `compatibility.yml` so they only fire when PRs target `main`, matching the existing restriction on `dco.yml` and `dependency-review.yml`.