### PR TITLE
fix: re-enable aube install scripts under mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,7 @@ install_before = "1d"
 biome = "2.4.13"
 bun = "1.3.14"
 node = "24.16.0"
-"npm:@endevco/aube" = "1.16.0"
+"npm:@endevco/aube" = { version = "1.16.0", npm_args = "--ignore-scripts=false" }
 
 [task_config]
 includes = [


### PR DESCRIPTION
## Summary

mise v2026.5.13 made the npm backend default to `--ignore-scripts=true`. `@endevco/aube` builds its `bin/` via a preinstall script and ships no `bin/` in its published tarball, so skipping scripts left `aube` uncreated and the compatibility test failed with `command not found: aube`. Setting `npm_args=--ignore-scripts=false` restores the preinstall.