### PR TITLE
chore: pin aube via aqua backend, drop redundant install_before

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,13 +1,10 @@
-min_version = "2026.4.8"
-
-[settings]
-install_before = "1d"
+min_version = "2026.6.3"
 
 [tools]
 biome = "2.4.13"
 bun = "1.3.14"
 node = "24.16.0"
-"npm:@endevco/aube" = { version = "1.18.1", npm_args = "--ignore-scripts=false" }
+"aqua:jdx/aube" = "1.18.1"
 
 [task_config]
 includes = [


### PR DESCRIPTION
mise v2026.6.2 defaults minimum_release_age to 24h, so drop the now-redundant install_before and raise min_version to 2026.6.3.

Pin aube through the aqua backend instead of the npm package.